### PR TITLE
Add `HyperlinkRelated` field for SQLAlchemy integration.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,9 +13,11 @@ env:
   - MARSHMALLOW_VERSION=""
 
 install:
-  - pip install -U -r dev-requirements.txt
-  - pip install -U .
-  - pip install -U marshmallow"$MARSHMALLOW_VERSION" --pre
+  - travis_retry pip install -U -r dev-requirements.txt
+  - travis_retry pip install -U .
+  - travis_retry pip install -U marshmallow"$MARSHMALLOW_VERSION" --pre
+  - travis_retry pip install -U git+https://github.com/jmcarp/marshmallow@set-field-attrs
+  - travis_retry pip install -U git+https://github.com/jmcarp/marshmallow-sqlalchemy@refactor-related
 before_script:
   - flake8 .
 script:  py.test

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,8 +16,8 @@ install:
   - travis_retry pip install -U -r dev-requirements.txt
   - travis_retry pip install -U .
   - travis_retry pip install -U marshmallow"$MARSHMALLOW_VERSION" --pre
-  - travis_retry pip install -U git+https://github.com/jmcarp/marshmallow@set-field-attrs
-  - travis_retry pip install -U git+https://github.com/jmcarp/marshmallow-sqlalchemy@refactor-related
+  - travis_retry pip install -U git+https://github.com/marshmallow-code/marshmallow@dev
+  - travis_retry pip install -U git+https://github.com/marshmallow-code/marshmallow-sqlalchemy@dev
 before_script:
   - flake8 .
 script:  py.test

--- a/flask_marshmallow/__init__.py
+++ b/flask_marshmallow/__init__.py
@@ -118,7 +118,6 @@ class Marshmallow(object):
 
         :param Flask app: The Flask application object.
         """
-        app.config.setdefault('MARSHMALLOW_LINK_ATTRIBUTE', 'url')
         app.extensions = getattr(app, 'extensions', {})
 
         # If using Flask-SQLAlchemy, attach db.session to ModelSchema

--- a/flask_marshmallow/__init__.py
+++ b/flask_marshmallow/__init__.py
@@ -109,7 +109,6 @@ class Marshmallow(object):
         self.Schema = Schema
         if has_sqla:
             self.ModelSchema = sqla.ModelSchema
-            self.HyperlinkModelSchema = sqla.HyperlinkModelSchema
         _attach_fields(self)
         if app is not None:
             self.init_app(app)
@@ -126,5 +125,4 @@ class Marshmallow(object):
         if has_sqla and 'sqlalchemy' in app.extensions:
             db = app.extensions['sqlalchemy'].db
             self.ModelSchema.OPTIONS_CLASS.session = db.session
-            self.HyperlinkModelSchema.OPTIONS_CLASS.session = db.session
         app.extensions[EXTENSION_NAME] = self

--- a/flask_marshmallow/sqla.py
+++ b/flask_marshmallow/sqla.py
@@ -11,6 +11,7 @@ from flask import url_for, current_app
 from six.moves.urllib import parse
 
 import marshmallow_sqlalchemy as msqla
+from marshmallow.exceptions import ValidationError
 from .schema import Schema
 
 class DummySession(object):
@@ -61,9 +62,16 @@ class HyperlinkRelated(msqla.fields.Related):
             value = parsed.path
         endpoint, kwargs = self.adapter.match(value)
         if endpoint != self.endpoint:
-            raise
+            raise ValidationError(
+                (
+                    'Parsed endpoint "{endpoint}" from URL "{value}"; expected '
+                    '"{self.endpoint}"'
+                ).format(**locals())
+            )
         if self.url_key not in kwargs:
-            raise
+            raise ValidationError(
+                'URL pattern "{self.url_key}" not found in {kwargs!r}'.format(**locals())
+            )
         return super(HyperlinkRelated, self)._deserialize(kwargs[self.url_key])
 
     @property

--- a/setup.py
+++ b/setup.py
@@ -8,6 +8,7 @@ from setuptools.command.test import test as TestCommand
 REQUIRES = [
     'Flask',
     'marshmallow>=1.2.0',
+    'six>=1.9.0',
 ]
 
 class PyTest(TestCommand):

--- a/test_flask_marshmallow.py
+++ b/test_flask_marshmallow.py
@@ -8,6 +8,7 @@ from flask_marshmallow import Marshmallow
 from flask_marshmallow.fields import _tpl
 
 from flask_sqlalchemy import SQLAlchemy
+from flask_marshmallow.sqla import HyperlinkRelated
 
 import marshmallow
 
@@ -341,40 +342,62 @@ class TestSQLAlchemy:
         resp = author_schema.jsonify(author)
         assert isinstance(resp, BaseResponse)
 
-    def test_can_declare_hyperlinked_model_schemas(self, extma, models, db, extapp):
-        class AuthorSchema(extma.HyperlinkModelSchema):
-            class Meta:
-                model = models.Author
-
-        class BookSchema(extma.HyperlinkModelSchema):
+    def test_hyperlink_related_field(self, extma, models, db, extapp):
+        class BookSchema(extma.ModelSchema):
             class Meta:
                 model = models.Book
+            author = HyperlinkRelated('author')
 
-        author_schema = AuthorSchema()
         book_schema = BookSchema()
 
         author = models.Author(name='Chuck Paluhniuk')
         book = models.Book(title='Fight Club', author=author)
         db.session.add(author)
         db.session.add(book)
-        db.session.commit()
+        db.session.flush()
 
         book_result = book_schema.dump(book)
         assert book_result.data['author'] == author.url
 
-        author_result = author_schema.dump(author)
-        assert author_result.data['books'][0] == book.url
+        deserialized = book_schema.load(book_result.data)
+        assert deserialized.data.author == author
 
-        extapp.config['MARSHMALLOW_LINK_ATTRIBUTE'] = 'absolute_url'
+    def test_hyperlink_related_field_external(self, extma, models, db, extapp):
+        class BookSchema(extma.ModelSchema):
+            class Meta:
+                model = models.Book
+            author = HyperlinkRelated('author', external=True)
+
+        book_schema = BookSchema()
+
+        author = models.Author(name='Chuck Paluhniuk')
+        book = models.Book(title='Fight Club', author=author)
+        db.session.add(author)
+        db.session.add(book)
+        db.session.flush()
 
         book_result = book_schema.dump(book)
         assert book_result.data['author'] == author.absolute_url
 
-        author_result = author_schema.dump(author)
-        assert author_result.data['books'][0] == book.absolute_url
+        deserialized = book_schema.load(book_result.data)
+        assert deserialized.data.author == author
 
-        author = author_schema.load(author_result.data).data
-        assert type(author) == models.Author
-        assert type(author.books[0]) == models.Book
-        assert author.books[0].title == book.title
-        assert author.books[0].id == book.id
+    def test_hyperlink_related_field_list(self, extma, models, db, extapp):
+        class AuthorSchema(extma.ModelSchema):
+            class Meta:
+                model = models.Author
+            books = extma.List(HyperlinkRelated('book'))
+
+        author_schema = AuthorSchema()
+
+        author = models.Author(name='Chuck Paluhniuk')
+        book = models.Book(title='Fight Club', author=author)
+        db.session.add(author)
+        db.session.add(book)
+        db.session.flush()
+
+        author_result = author_schema.dump(author)
+        assert author_result.data['books'][0] == book.url
+
+        deserialized = author_schema.load(author_result.data)
+        assert deserialized.data.books[0] == book

--- a/tox.ini
+++ b/tox.ini
@@ -5,6 +5,8 @@ deps=
     pytest
     Flask
     mock
-    marshmallow
+    Flask-SQLAlchemy
+    git+https://github.com/marshmallow-code/marshmallow@dev
+    git+https://github.com/marshmallow-code/marshmallow-sqlalchemy@dev
 commands=
     py.test test_flask_marshmallow.py


### PR DESCRIPTION
Second attempt at https://github.com/marshmallow-code/marshmallow-sqlalchemy/pull/10.

Note: depends on https://github.com/marshmallow-code/marshmallow-sqlalchemy/pull/8 and https://github.com/marshmallow-code/marshmallow/pull/230.
