### PR TITLE
Clarify that Flask jsonify() overrides ordered=True in class Meta

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -174,8 +174,8 @@ You can now use your schema to dump and load your ORM objects.
 `ModelSchema <flask_marshmallow.sqla.ModelSchema>` is nearly identical in API to `marshmallow_sqlalchemy.ModelSchema` with the following exceptions:
 
 - By default, `ModelSchema <flask_marshmallow.sqla.ModelSchema>` uses the scoped session created by Flask-SQLAlchemy.
-- `ModelSchema <flask_marshmallow.sqla.ModelSchema>` subclasses `flask_marshmallow.Schema`, so it includes the `jsonify <flask_marshmallow.Schema.jsonify>` method.
-
+- `ModelSchema <flask_marshmallow.sqla.ModelSchema>` subclasses `flask_marshmallow.Schema`, so it includes the `jsonify <flask_marshmallow.Schema.jsonify>` method. 
+Note: By default, Flask's `jsonify` method sorts the list of keys and returns consistent results to ensure that external HTTP caches aren't trashed. As a side effect, this will override ``ordered=True`<https://marshmallow.readthedocs.org/en/latest/quickstart.html#ordering-output>`_ in the ModelSchema's `class Meta` (if you set it). To disable this, set `JSON_SORT_KEYS=False` in your Flask app config. In production it's recommended to let `jsonify` sort the keys and not set `ordered=True` in your `ModelSchema <flask_marshmallow.sqla.ModelSchema>` in order to minimize generation time and maximize cachability of the results.
 
 You can also use `ma.HyperlinkModelSchema <flask_marshmallow.sqla.HyperlinkModelSchema>` if you want relationships to be represented by hyperlinks rather than primary keys. Models MUST have a ``url`` attribute or property.
 


### PR DESCRIPTION
Not sure the formatting is correct for sphinx, but the content is useful. Happy to fix if anything's amiss.

`ordered=True` won't propagate to flask-marshmallow until https://github.com/marshmallow-code/marshmallow-sqlalchemy/issues/52 is fixed, but looks like @jmcarp already is on top of that. 
