### PR TITLE
`many` argument to `Schema.jsonify()` should default to `Schema.many`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,7 @@ lib64
 pip-log.txt
 
 # Unit test / coverage reports
+.cache
 .coverage
 .tox
 nosetests.xml

--- a/flask_marshmallow/schema.py
+++ b/flask_marshmallow/schema.py
@@ -2,23 +2,35 @@
 import flask
 import marshmallow as ma
 
+sentinel = object()
+
 class Schema(ma.Schema):
     """Base serializer with which to define custom serializers.
 
     See `marshmallow.Schema` for more details about the `Schema` API.
     """
 
-    def jsonify(self, obj, many=False, *args, **kwargs):
+    def jsonify(self, obj, many=sentinel, *args, **kwargs):
         """Return a JSON response containing the serialized data.
 
 
         :param obj: Object to serialize.
-        :param bool many: Set to `True` if `obj` should be serialized as a collection.
+        :param bool many: Whether `obj` should be serialized as an instance
+            or as a collection. If unset, defaults to the value of the
+            `many` attribute on this Schema.
         :param kwargs: Additional keyword arguments passed to `flask.jsonify`.
 
         .. versionchanged:: 0.6.0
             Takes the same arguments as `marshmallow.Schema.dump`. Additional
             keyword arguments are passed to `flask.jsonify`.
+
+        .. versionchanged:: 0.6.3
+            The `many` argument for this method defaults to the value of
+            the `many` attribute on the Schema. Previously, the `many`
+            argument of this method defaulted to False, regardless of the
+            value of `Schema.many`.
         """
+        if many is sentinel:
+            many = self.many
         data = self.dump(obj, many=many).data
         return flask.jsonify(data, *args, **kwargs)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -24,6 +24,13 @@ def mockauthor():
     return author
 
 @pytest.fixture
+def mockauthorlist():
+    a1 = Author(id=1, name="Alice")
+    a2 = Author(id=2, name="Bob")
+    a3 = Author(id=3, name="Carol")
+    return [a1, a2, a3]
+
+@pytest.fixture
 def mockbook(mockauthor):
     book = Book(id=42, author=mockauthor, title='Legend of Bagger Vance')
     return book

--- a/tests/markers.py
+++ b/tests/markers.py
@@ -1,8 +1,19 @@
 import pytest
 import marshmallow
+import flask
+from distutils.version import LooseVersion
+
+
+marshmallow_version = LooseVersion(marshmallow.__version__)
+flask_version = LooseVersion(flask.__version__)
 
 
 marshmallow_2_req = pytest.mark.skipif(
-    int(marshmallow.__version__.split('.')[0]) < 2,
+    marshmallow_version < LooseVersion("2.0"),
     reason="marshmallow 2.0 or higher required",
+)
+
+flask_1_req = pytest.mark.skipif(
+    flask_version < LooseVersion("0.11"),
+    reason="flask 0.11 or higher required",
 )

--- a/tests/markers.py
+++ b/tests/markers.py
@@ -1,0 +1,8 @@
+import pytest
+import marshmallow
+
+
+marshmallow_2_req = pytest.mark.skipif(
+    int(marshmallow.__version__.split('.')[0]) < 2,
+    reason="marshmallow 2.0 or higher required",
+)

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -41,6 +41,15 @@ def test_jsonify_collection(app, schemas, mockauthorlist):
     obj = json.loads(resp.get_data(as_text=True))
     assert isinstance(obj, list)
 
+@flask_1_req
+def test_jsonify_collection_via_schema_attr(app, schemas, mockauthorlist):
+    s = schemas.AuthorSchema(many=True)
+    resp = s.jsonify(mockauthorlist)
+    assert isinstance(resp, BaseResponse)
+    assert resp.content_type == 'application/json'
+    obj = json.loads(resp.get_data(as_text=True))
+    assert isinstance(obj, list)
+
 def test_links_within_nested_object(app, schemas, mockbook):
     s = schemas.BookSchema()
     result = s.dump(mockbook)

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1,7 +1,10 @@
 # -*- coding: utf-8 -*-
+import json
 from flask import Flask, url_for
 from werkzeug.wrappers import BaseResponse
 from flask_marshmallow import Marshmallow
+
+from tests.markers import flask_1_req
 
 def test_deferred_initialization():
     app = Flask(__name__)
@@ -21,11 +24,22 @@ def test_schema(app, schemas, mockauthor):
     assert links['self'] == url_for('author', id=mockauthor.id)
     assert links['collection'] == url_for('authors')
 
-def test_jsonify(app, schemas, mockauthor):
+def test_jsonify_instance(app, schemas, mockauthor):
     s = schemas.AuthorSchema()
     resp = s.jsonify(mockauthor)
     assert isinstance(resp, BaseResponse)
     assert resp.content_type == 'application/json'
+    obj = json.loads(resp.get_data(as_text=True))
+    assert isinstance(obj, dict)
+
+@flask_1_req
+def test_jsonify_collection(app, schemas, mockauthorlist):
+    s = schemas.AuthorSchema()
+    resp = s.jsonify(mockauthorlist, many=True)
+    assert isinstance(resp, BaseResponse)
+    assert resp.content_type == 'application/json'
+    obj = json.loads(resp.get_data(as_text=True))
+    assert isinstance(obj, list)
 
 def test_links_within_nested_object(app, schemas, mockbook):
     s = schemas.BookSchema()

--- a/tests/test_sqla.py
+++ b/tests/test_sqla.py
@@ -4,15 +4,13 @@ from flask_marshmallow import Marshmallow
 from flask_marshmallow.sqla import HyperlinkRelated
 from flask_sqlalchemy import SQLAlchemy
 from werkzeug.wrappers import BaseResponse
-import marshmallow
 import pytest
 
 from tests.conftest import Bunch
+from tests.markers import marshmallow_2_req
 
-MARSHMALLOW_2 = int(marshmallow.__version__.split('.')[0]) >= 2
 
-@pytest.mark.skipif(not MARSHMALLOW_2, reason='marshmallow-sqlalchemy '
-                    'not supported in marshmallow<2.0')
+@marshmallow_2_req
 class TestSQLAlchemy:
 
     @pytest.yield_fixture()


### PR DESCRIPTION
I was very confused by the `Schema.jsonify()` API for collections -- I had to read through the code to understand what I was supposed to do. I thought that I only had to set `Schema.many` and everything would just work, but it turns out there's a `many` attribute to `Schema.jsonify()` that is handled completely separately. I figured it would make sense for `jsonify()` to know about `Schema.many`, so this pull request makes the change in a backwards-compatible manner.

I think that a _better_ change would be removing the `many` argument from `Schema.jsonify()` entirely, and letting `Schema.many` control the mechanism entirely. However, I believe that removing that argument would break backwards compatibility, so I left it in for this pull request.

Note that the current released version of Flask does not allow passing a list to `flask.jsonify()`, and it will barf if you try. However, [a recent pull request to Flask removes that restriction](https://github.com/pallets/flask/pull/1671), so this functionality should work in Flask 1.0 -- or in bleeding-edge versions of Flask, if you swing that way. The new tests will be skipped if you use any version of Flask that is below 0.11 (bleeding edge).
