### PR TITLE
Convert readthedocs link for their .org -> .io migration for hosted projects

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -96,7 +96,7 @@ To learn more about marshmallow, check out its `docs <http://marshmallow.readthe
 Project Links
 =============
 
-- Docs: http://flask-marshmallow.rtfd.org/
+- Docs: https://flask-marshmallow.readthedocs.io/
 - Changelog: http://flask-marshmallow.readthedocs.io/en/latest/changelog.html
 - PyPI: https://pypi.python.org/pypi/flask-marshmallow
 - Issues: https://github.com/marshmallow-code/flask-marshmallow/issues


### PR DESCRIPTION
As per [their blog post of the 27th April](https://blog.readthedocs.com/securing-subdomains/) ‘Securing subdomains’:

> Starting today, Read the Docs will start hosting projects from subdomains on the domain readthedocs.io, instead of on readthedocs.org. This change addresses some security concerns around site cookies while hosting user generated data on the same domain as our dashboard.

Test Plan: Manually visited all the links I’ve modified.
