### PR TITLE
Update docs so UserSchema _links point to correct routes

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,11 @@
 Changelog
 =========
 
+Unreleased
+**********
+
+* Updated documentation to fix example ``ma.URLFor`` target.
+
 0.8.0 (2017-05-28)
 ******************
 
@@ -8,7 +13,7 @@ Changelog
 
 Support:
 
-* *Backwards-incompatible*: Drop support for marshmallow<=2.0.0. 
+* *Backwards-incompatible*: Drop support for marshmallow<=2.0.0.
 * Test against Python 3.6.
 
 0.7.0 (2016-06-28)

--- a/README.rst
+++ b/README.rst
@@ -49,8 +49,8 @@ Define your output format with marshmallow.
             fields = ('email', 'date_created', '_links')
         # Smart hyperlinking
         _links = ma.Hyperlinks({
-            'self': ma.URLFor('author_detail', id='<id>'),
-            'collection': ma.URLFor('authors')
+            'self': ma.URLFor('user_detail', id='<id>'),
+            'collection': ma.URLFor('users')
         })
 
     user_schema = UserSchema()
@@ -77,8 +77,8 @@ Output the data in your views.
     #     "email": "fred@queen.com",
     #     "date_created": "Fri, 25 Apr 2014 06:02:56 -0000",
     #     "_links": {
-    #         "self": "/api/authors/42",
-    #         "collection": "/api/authors/"
+    #         "self": "/api/users/42",
+    #         "collection": "/api/users/"
     #     }
     # }
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -53,8 +53,8 @@ Define your output format with marshmallow.
             fields = ('email', 'date_created', '_links')
         # Smart hyperlinking
         _links = ma.Hyperlinks({
-            'self': ma.URLFor('author_detail', id='<id>'),
-            'collection': ma.URLFor('authors')
+            'self': ma.URLFor('user_detail', id='<id>'),
+            'collection': ma.URLFor('users')
         })
 
     user_schema = UserSchema()
@@ -81,8 +81,8 @@ Output the data in your views.
     #     "email": "fred@queen.com",
     #     "date_created": "Fri, 25 Apr 2014 06:02:56 -0000",
     #     "_links": {
-    #         "self": "/api/authors/42",
-    #         "collection": "/api/authors/"
+    #         "self": "/api/users/42",
+    #         "collection": "/api/users/"
     #     }
     # }
 


### PR DESCRIPTION
Alternatively, I can rename `UserSchema` to `AuthorSchema` for consistency with the examples nearly everywhere else.

I have a minor preference for the separation from the `AuthorSchema` in later examples because I know I don't have to keep context from the top of the page when I'm reading them, but I'm happy to fix it either way.