### PR TITLE
update hyperlinkrelated to gracefully support nullable / non-required sqla relations

### DIFF
--- a/flask_marshmallow/sqla.py
+++ b/flask_marshmallow/sqla.py
@@ -8,6 +8,7 @@
     from Flask-SQLALchemy.
 """
 from flask import url_for, current_app
+from werkzeug.routing import BuildError
 from six.moves.urllib import parse
 
 import marshmallow_sqlalchemy as msqla
@@ -62,7 +63,13 @@ class HyperlinkRelated(msqla.fields.Related):
     def _serialize(self, value, attr, obj):
         key = super(HyperlinkRelated, self)._serialize(value, attr, obj)
         kwargs = {self.url_key: key}
-        return url_for(self.endpoint, _external=self.external, **kwargs)
+        try:
+            return url_for(self.endpoint, _external=self.external, **kwargs)
+        except BuildError as e:
+            if not self.required:
+                return self.missing if self.missing else None
+            else:
+                raise e
 
     def _deserialize(self, value, *args, **kwargs):
         if self.external:


### PR DESCRIPTION
I have nullable relations on my SQLAlchemy models that blow up when deserializing HyperlinkRelated. Patch allows for graceful failure when base field is not-required. 

Similar to the issue listed here: https://github.com/marshmallow-code/flask-marshmallow/issues/18