### PR TITLE
Use ModelSchema.session setter rather than OPTIONS_CLASS

### DIFF
--- a/flask_marshmallow/__init__.py
+++ b/flask_marshmallow/__init__.py
@@ -124,5 +124,5 @@ class Marshmallow(object):
         # If using Flask-SQLAlchemy, attach db.session to ModelSchema
         if has_sqla and 'sqlalchemy' in app.extensions:
             db = app.extensions['sqlalchemy'].db
-            self.ModelSchema.OPTIONS_CLASS.session = db.session
+            self.ModelSchema.session = db.session
         app.extensions[EXTENSION_NAME] = self


### PR DESCRIPTION
When I use webargs with flask-marshmallow, there is an issue whereby webargs [calls](https://github.com/marshmallow-code/webargs/blob/7d16a45865dbc6120b5d42dadaf926affe66c24e/webargs/core.py#L356) `schema.load(parsed)`, and fails because the `DummySession` is returned instead of the sqlalchemy scoped session.

I am relying on `init_app()` to bind the sqlalchemy session. I can see from other issues that people have suggested passing `sqla_session` in `Meta`, but I'd rather not copy and paste boilerplate if I can avoid it. Looking at the [relevant line](https://github.com/marshmallow-code/marshmallow-sqlalchemy/blob/bb0cbb9310592802874d269744bf159b576db490/marshmallow_sqlalchemy/schema.py#L189) in marshmallow-sqlalchemy, it looks like `ModelSchema.load` expects `self._session` to be set, which `ModelSchema.OPTIONS_CLASS.session` doesn't do, but the setter does.

The tests still pass, but as a new user of this ecosystem, I'd be happy to know if I've missed something. In particular, I know a lot of people use this stuff, so I'm not sure how it works for others.