### PR TITLE
Fixes docs discrepancy between `user_schema` and `users_schema`

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -71,7 +71,7 @@ Output the data in your views.
         result = users_schema.dump(all_users)
         return jsonify(result.data)
         # OR
-        # return user_schema.jsonify(all_users)
+        # return users_schema.jsonify(all_users)
 
     @app.route('/api/users/<id>')
     def user_detail(id):


### PR DESCRIPTION
`user_schema.jsonify(all_users)` will return an empty dictionary because `user_schema` is instantiated with `many=False`. The docs should reference `users_schema.jsonify(all_users)` to return a json serialized version of the list of users. Alternatively `user_schema(all_users, many=True)` can be used to override the default value of `many` from the `Schema` object.