### PR TITLE
Properly handle None in HyperlinkRelated, URLFor, etc.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -10,6 +10,13 @@ Features:
 * SQLAlchemy requirements can be installed with ``pip install
   'flask-marshmallow[sqlalchemy]'``.
 
+
+Bug fixes:
+
+* ``URLFor`` serializes to ``None`` if a passed attribute value is
+  ``None`` (:issue:`18`, :issue:`68`). Thanks :user:`RobinRamuel` and
+  :user:`ocervell` for reporting.
+
 Support:
 
 * Test against Python 3.7.

--- a/flask_marshmallow/compat.py
+++ b/flask_marshmallow/compat.py
@@ -3,16 +3,7 @@
 This module should be considered private API.
 """
 import marshmallow
-from marshmallow.utils import get_value as _get_value
 
 _MARSHMALLOW_VERSION_INFO = tuple(
     [int(part) for part in marshmallow.__version__.split(".") if part.isdigit()]
 )
-
-# marshmallow>=3.0 switches the order of the obj and attr arguments from previous versions
-if _MARSHMALLOW_VERSION_INFO[0] >= 3:
-    get_value = _get_value
-else:
-
-    def get_value(obj, attr, *args, **kwargs):
-        return _get_value(attr, obj, *args, **kwargs)

--- a/flask_marshmallow/fields.py
+++ b/flask_marshmallow/fields.py
@@ -127,7 +127,6 @@ class Hyperlinks(fields.Field):
         _links = Hyperlinks({
             'self': URLFor('author', id='<id>'),
             'collection': URLFor('author_list'),
-            }
         })
 
     `URLFor` objects can be nested within the dictionary. ::

--- a/flask_marshmallow/fields.py
+++ b/flask_marshmallow/fields.py
@@ -15,12 +15,11 @@ from marshmallow import fields
 from marshmallow.compat import iteritems
 from marshmallow import missing
 
-from .compat import get_value
+
+__all__ = ["URLFor", "UrlFor", "AbsoluteURLFor", "AbsoluteUrlFor", "Hyperlinks"]
 
 
 _tpl_pattern = re.compile(r"\s*<\s*(\S*)\s*>\s*")
-
-__all__ = ["URLFor", "UrlFor", "AbsoluteURLFor", "AbsoluteUrlFor", "Hyperlinks"]
 
 
 def _tpl(val):
@@ -29,6 +28,38 @@ def _tpl(val):
     if match:
         return match.groups()[0]
     return None
+
+
+def _get_value(obj, key, default=missing):
+    """Slightly-modified version of marshmallow.utils.get_value.
+    If a dot-delimited ``key`` is passed and any attribute in the
+    path is `None`, return `None`.
+    """
+    if "." in key:
+        return _get_value_for_keys(obj, key.split("."), default)
+    else:
+        return _get_value_for_key(obj, key, default)
+
+
+def _get_value_for_keys(obj, keys, default):
+    if len(keys) == 1:
+        return _get_value_for_key(obj, keys[0], default)
+    else:
+        value = _get_value_for_key(obj, keys[0], default)
+        # XXX This differs from the marshmallow implementation
+        if value is None:
+            return None
+        return _get_value_for_keys(value, keys[1:], default)
+
+
+def _get_value_for_key(obj, key, default):
+    if not hasattr(obj, "__getitem__"):
+        return getattr(obj, key, default)
+
+    try:
+        return obj[key]
+    except (KeyError, IndexError, TypeError, AttributeError):
+        return getattr(obj, key, default)
 
 
 class URLFor(fields.Field):
@@ -65,7 +96,9 @@ class URLFor(fields.Field):
         for name, attr_tpl in iteritems(self.params):
             attr_name = _tpl(str(attr_tpl))
             if attr_name:
-                attribute_value = get_value(obj, attr_name, default=missing)
+                attribute_value = _get_value(obj, attr_name, default=missing)
+                if attribute_value is None:
+                    return None
                 if attribute_value is not missing:
                     param_values[name] = attribute_value
                 else:

--- a/flask_marshmallow/sqla.py
+++ b/flask_marshmallow/sqla.py
@@ -83,6 +83,8 @@ class HyperlinkRelated(msqla.fields.Related):
         self.external = external
 
     def _serialize(self, value, attr, obj):
+        if value is None:
+            return None
         key = super(HyperlinkRelated, self)._serialize(value, attr, obj)
         kwargs = {self.url_key: key}
         return url_for(self.endpoint, _external=self.external, **kwargs)

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -34,6 +34,24 @@ def test_url_field_with_invalid_attribute(ma, mockauthor):
     assert expected_msg in str(excinfo)
 
 
+def test_url_field_handles_nested_attribute(ma, mockbook, mockauthor):
+    field = ma.URLFor("author", id="<author.id>")
+    result = field.serialize("url", mockbook)
+    assert result == url_for("author", id=mockauthor.id)
+
+
+def test_url_field_handles_none_attribute(ma, mockbook, mockauthor):
+    mockbook.author = None
+
+    field = ma.URLFor("author", id="<author>")
+    result = field.serialize("url", mockbook)
+    assert result is None
+
+    field = ma.URLFor("author", id="<author.id>")
+    result = field.serialize("url", mockbook)
+    assert result is None
+
+
 def test_url_field_deserialization(ma):
     field = ma.URLFor("author", id="<not-an-attr>", allow_none=True)
     # noop

--- a/tests/test_sqla.py
+++ b/tests/test_sqla.py
@@ -159,6 +159,18 @@ class TestSQLAlchemy:
         deserialized, errors = get_load_data(book_schema, book_result)
         assert deserialized.author == author
 
+    def test_hyperlink_related_field_serializes_none(self, extma, models):
+        class BookSchema(extma.ModelSchema):
+            class Meta:
+                model = models.Book
+
+            author = extma.HyperlinkRelated("author")
+
+        book_schema = BookSchema()
+        book = models.Book(title="Fight Club", author=None)
+        book_result = get_dump_data(book_schema, book)
+        assert book_result["author"] is None
+
     def test_hyperlink_related_field_errors(self, extma, models, db, extapp):
         class BookSchema(extma.ModelSchema):
             class Meta:
@@ -178,7 +190,6 @@ class TestSQLAlchemy:
         book_result = get_dump_data(book_schema, book)
         book_result["author"] = book.url
         deserialized, errors = get_load_data(book_schema, book_result)
-        print(errors)
         assert 'expected "author"' in errors["author"][0]
 
         # Deserialization fails on bad URL key


### PR DESCRIPTION
With this change, fields serialize `None` to `None`, which is consistent with the behavior of built-in marshmallow fields.

close #72 
close #18 
close #68