### PR TITLE
Target depreciation warnings

### DIFF
--- a/src/flask_marshmallow/__init__.py
+++ b/src/flask_marshmallow/__init__.py
@@ -95,8 +95,6 @@ class Marshmallow(object):
     def __init__(self, app=None):
         self.Schema = Schema
         if has_sqla:
-            self.ModelSchema = sqla.ModelSchema
-            self.TableSchema = sqla.TableSchema
             self.SQLAlchemySchema = sqla.SQLAlchemySchema
             self.SQLAlchemyAutoSchema = sqla.SQLAlchemyAutoSchema
             self.auto_field = sqla.auto_field
@@ -115,5 +113,17 @@ class Marshmallow(object):
         # If using Flask-SQLAlchemy, attach db.session to ModelSchema
         if has_sqla and "sqlalchemy" in app.extensions:
             db = app.extensions["sqlalchemy"].db
-            self.ModelSchema.OPTIONS_CLASS.session = db.session
+            sqla.FlaskSQLAlchemyOptsMixin.session = db.session
         app.extensions[EXTENSION_NAME] = self
+
+    @property
+    def ModelSchema(self):
+        if has_sqla:
+            return sqla.ModelSchema
+        raise AttributeError("'%s' object has no attribute 'ModelSchema'" % type(self))
+
+    @property
+    def TableSchema(self):
+        if has_sqla:
+            return sqla.TableSchema
+        raise AttributeError("'%s' object has no attribute 'TableSchema'" % type(self))

--- a/src/flask_marshmallow/sqla.py
+++ b/src/flask_marshmallow/sqla.py
@@ -192,25 +192,6 @@ if sys.version_info >= (3, 7):
 
         raise AttributeError("module {} has no attribute {}".format(__name__, name))
 
-    def __dir__():
-        return [
-            "DummySession",
-            "FlaskSQLAlchemyOptsMixin",
-            "HyperlinkRelated",
-            "SQLAlchemyAutoSchema",
-            "SQLAlchemyAutoSchemaOpts",
-            "SQLAlchemySchema",
-            "SQLAlchemySchemaOpts",
-            "Schema",
-            "SchemaOpts",
-            "ValidationError",
-            "auto_field",
-            "current_app",
-            "msqla",
-            "parse",
-            "url_for",
-        ]
-
 
 else:
 
@@ -222,25 +203,6 @@ else:
         SQLAlchemyAutoSchema = SQLAlchemyAutoSchema
         auto_field = staticmethod(auto_field)
         HyperlinkRelated = HyperlinkRelated
-
-        def __dir__(self):
-            return [
-                "DummySession",
-                "FlaskSQLAlchemyOptsMixin",
-                "HyperlinkRelated",
-                "SQLAlchemyAutoSchema",
-                "SQLAlchemyAutoSchemaOpts",
-                "SQLAlchemySchema",
-                "SQLAlchemySchemaOpts",
-                "Schema",
-                "SchemaOpts",
-                "ValidationError",
-                "auto_field",
-                "current_app",
-                "msqla",
-                "parse",
-                "url_for",
-            ]
 
         def __getattr__(self, name):
             if name == "ModelSchema":

--- a/tests/test_sqla.py
+++ b/tests/test_sqla.py
@@ -1,4 +1,6 @@
 # -*- coding: utf-8 -*-
+import warnings
+
 import pytest
 from flask import Flask, url_for
 from flask_sqlalchemy import SQLAlchemy
@@ -329,3 +331,73 @@ class TestSQLAlchemy:
 
         deserialized, errors = get_load_data(author_schema, author_result)
         assert deserialized.books[0] == book
+
+    @pytest.mark.skipif(
+        not has_sqlalchemyschema, reason="SQLAlchemyAutoSchema not available"
+    )
+    def test_no_warn_sqla_schemas(self, extma, models):
+        warnings.simplefilter("always")
+
+        with pytest.warns(None) as record:
+
+            class AuthorSchema(extma.SQLAlchemySchema):
+                class Meta:
+                    model = models.Author
+
+            class BookSchema(extma.SQLAlchemySchema):
+                class Meta:
+                    model = models.Book
+
+        assert len(record) == 0
+
+    @pytest.mark.skipif(
+        not has_sqlalchemyschema, reason="SQLAlchemyAutoSchema not available"
+    )
+    def test_no_warn_sqla_auto_schemas(self, extma, models):
+        warnings.simplefilter("always")
+
+        with pytest.warns(None) as record:
+
+            class AuthorSchema(extma.SQLAlchemyAutoSchema):
+                class Meta:
+                    model = models.Author
+
+            class BookSchema(extma.SQLAlchemyAutoSchema):
+                class Meta:
+                    model = models.Book
+
+        assert len(record) == 0
+
+    @pytest.mark.skipif(
+        not has_sqlalchemyschema, reason="SQLAlchemyAutoSchema not available"
+    )
+    def test_warns_model_schema(self, extma, models):
+
+        with pytest.deprecated_call():
+
+            class AuthorSchema(extma.ModelSchema):
+                class Meta:
+                    model = models.Author
+
+        with pytest.deprecated_call():
+
+            class BookSchema(extma.ModelSchema):
+                class Meta:
+                    model = models.Book
+
+    @pytest.mark.skipif(
+        not has_sqlalchemyschema, reason="SQLAlchemyAutoSchema not available"
+    )
+    def test_warns_table_schema(self, extma, models):
+
+        with pytest.deprecated_call():
+
+            class AuthorSchema(extma.TableSchema):
+                class Meta:
+                    table = models.Author.__table__
+
+        with pytest.deprecated_call():
+
+            class BookSchema(extma.TableSchema):
+                class Meta:
+                    table = models.Book.__table__


### PR DESCRIPTION
I thought I'd have a go at solving #173 

This makes a couple of changes to get the depreciation warnings from marshmallow-sqlalchemy to only sound if the depreciated classes are accessed.

For py3.7+ it makes use of module `__getattr__()` to call functions that build the depreciated classes on access.

For earlier py versions, it makes a fake module class to leverage the instance `__getattr__()` method to do the same as the 3.7+ code. (https://stackoverflow.com/questions/2447353/getattr-on-a-module and https://github.com/pallets/werkzeug/blob/d902d2c05a2cb3d7d1f5414fe9c678273f5ffa05/werkzeug/__init__.py#L113-L157)

It modifies the `Marshmallow.init_app()` method to put the session on to the `sqla.FlaskSQLAlchemyOptsMixin.session` if its available; so that the warning for `ModelSchema` isn't triggered when instantiating the extension. I chose to put it there as this means it will also make the session available for the new sqlalchemy schema classes. Otherwise the session could be put onto `sqla.SchemaOpts.session` to get the behavior closer to existing.