### PR TITLE
Add FlaskConfig field

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,13 @@ Changelog
 0.15.0 (unreleased)
 *******************
 
+Features:
+
+* Add new ``FlaskConfig()`` field type, to automatically serialise values from the
+  :ref:`Flask configuration object <flask:config>`.
+
+Other changes:
+
 * Only support Python>=3.6, marshmallow>=3.0.0, and marshmallow-sqlalchemy>=0.24.0.
 
 0.14.0 (2020-09-27)

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,7 +7,7 @@ Changelog
 Features:
 
 * Add new ``FlaskConfig()`` field type, to automatically serialise values from the
-  :ref:`Flask configuration object <flask:config>`.
+  :ref:`Flask configuration object <flask:config>` (:issue:`212`, :pr:`222`).
 
 Other changes:
 

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -1,4 +1,7 @@
-from flask import url_for
+from datetime import date, timedelta
+
+from flask import current_app, url_for
+from marshmallow import ValidationError
 from werkzeug.routing import BuildError
 import pytest
 from flask_marshmallow.fields import _tpl
@@ -157,3 +160,147 @@ def test_aliases(ma):
 
     assert UrlFor is URLFor
     assert AbsoluteUrlFor is AbsoluteURLFor
+
+
+@pytest.mark.usefixtures("app")
+class TestFlaskConfig:
+    def test_unbound(self, ma):
+        assert ma.FlaskConfig().config_name is None
+
+    def test_copy_inner_on_bind(self, ma):
+        # binding creates copies
+        inner = ma.String()
+        field = ma.FlaskConfig(inner)
+        field._bind_to_schema("field_name", ma.Schema())
+        assert field.inner is not inner
+
+    def test_defaults(self, ma):
+        class TestSchema(ma.Schema):
+            # defaults: use field name as ACME_FOO, type String
+            acme_foo = ma.FlaskConfig()
+
+            # only specify field type
+            acme_bar = ma.FlaskConfig(ma.Integer)
+
+            # specify both
+            monty = ma.FlaskConfig(
+                ma.TimeDelta(precision=ma.TimeDelta.MINUTES), "ACME_MONTY_PYTHON_OFFSET"
+            )
+
+        schema = TestSchema()
+
+        foo = schema.fields["acme_foo"]
+        assert isinstance(foo.inner, ma.String)
+        assert foo.config_name == "ACME_FOO"
+
+        bar = schema.fields["acme_bar"]
+        assert isinstance(bar.inner, ma.Integer)
+        assert bar.config_name == "ACME_BAR"
+
+        monty = schema.fields["monty"]
+        assert isinstance(monty.inner, ma.TimeDelta)
+        assert monty.config_name == "ACME_MONTY_PYTHON_OFFSET"
+
+        current_app.config.update(
+            {
+                "ACME_FOO": "foo_value",
+                "ACME_BAR": 42,
+                "ACME_MONTY_PYTHON_OFFSET": timedelta(minutes=17, seconds=23),
+            }
+        )
+
+        data = schema.dump({})
+        assert data == {
+            "acme_foo": "foo_value",
+            "acme_bar": 42,
+            "monty": 17,
+        }
+
+    def test_nested(self, ma):
+        class AcmeNested(ma.Schema):
+            spam = ma.String()
+            ham = ma.Date()
+
+        class TestSchema(ma.Schema):
+            vikings = ma.FlaskConfig(ma.Nested(AcmeNested), "ACME_VIKING_CONFIG")
+
+        current_app.config.update(
+            {
+                "ACME_VIKING_CONFIG": {
+                    "spam": "spam spam spam spam",
+                    "ham": date(1970, 12, 15),
+                },
+            }
+        )
+        data = TestSchema().dump({})
+        assert data == {"vikings": {"spam": "spam spam spam spam", "ham": "1970-12-15"}}
+
+    @pytest.mark.parametrize(
+        "field_kwargs", ({"only": ("ham",)}, {"exclude": ("spam",)})
+    )
+    def test_nested_field_config(self, ma, field_kwargs):
+        class AcmeNested(ma.Schema):
+            spam = ma.String()
+            ham = ma.Date()
+
+        class TestSchema(ma.Schema):
+            vikings = ma.FlaskConfig(
+                ma.Nested(AcmeNested, **field_kwargs), "ACME_VIKING_CONFIG"
+            )
+
+        current_app.config.update(
+            {
+                "ACME_VIKING_CONFIG": {
+                    "spam": "spam spam spam spam",
+                    "ham": date(1970, 12, 15),
+                },
+            }
+        )
+        data = TestSchema().dump({})
+        assert data == {"vikings": {"ham": "1970-12-15"}}
+
+    @pytest.mark.parametrize(
+        "schema_kwargs", ({"only": ("vikings.ham",)}, {"exclude": ("vikings.spam",)})
+    )
+    def test_nested_schema_config(self, ma, schema_kwargs):
+        class AcmeNested(ma.Schema):
+            spam = ma.String()
+            ham = ma.Date()
+
+        class TestSchema(ma.Schema):
+            vikings = ma.FlaskConfig(ma.Nested(AcmeNested), "ACME_VIKING_CONFIG")
+
+        current_app.config.update(
+            {
+                "ACME_VIKING_CONFIG": {
+                    "spam": "spam spam spam spam",
+                    "ham": date(1970, 12, 15),
+                },
+            }
+        )
+        data = TestSchema(**schema_kwargs).dump({})
+        assert data == {"vikings": {"ham": "1970-12-15"}}
+
+    def test_dump_only_default(self, ma):
+        class TestSchema(ma.Schema):
+            foo = ma.FlaskConfig(config_name="ACME_FOO")
+
+        data = {"foo": "incoming value"}
+        current_app.config["ACME_FOO"] = "current value"
+        with pytest.raises(ValidationError) as context:
+            TestSchema().load(data)
+        assert "foo" in context.value.messages
+        assert current_app.config["ACME_FOO"] == "current value"
+
+    def test_dump_only_false(self, ma):
+        class TestSchema(ma.Schema):
+            foo = ma.FlaskConfig(config_name="ACME_FOO", dump_only=False)
+
+        data = {"foo": "incoming value"}
+        current_app.config["ACME_FOO"] = "current value"
+        deser = TestSchema().load(data)
+        assert current_app.config["ACME_FOO"] == "incoming value"
+        assert deser == {}
+
+    # TODO
+    # - [ ] loading

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -301,6 +301,3 @@ class TestFlaskConfig:
         deser = TestSchema().load(data)
         assert current_app.config["ACME_FOO"] == "incoming value"
         assert deser == {}
-
-    # TODO
-    # - [ ] loading


### PR DESCRIPTION
Implementation for #212.

On dump, the field sources its data from the configured Flask config value.

By default, the field is dump-only (read-only), but it can be configured to update the configuration on load. This is however not smart enough to deal with nested structures and a limited view on the existing configuration value.

The included type hints follow the pattern set by Marshmallow.
