### PR TITLE
Pin black importlib metadata dependencies

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,21 +1,21 @@
 repos:
 - repo: https://github.com/asottile/pyupgrade
-  rev: v2.11.0
+  rev: v2.31.0
   hooks:
   - id: pyupgrade
     args: [--py36-plus]
 - repo: https://github.com/python/black
-  rev: 20.8b1
+  rev: 22.3.0
   hooks:
   - id: black
     language_version: python3
 - repo: https://gitlab.com/pycqa/flake8
-  rev: 3.9.0
+  rev: 3.9.2
   hooks:
   - id: flake8
-    additional_dependencies: [flake8-bugbear==21.4.3]
+    additional_dependencies: [flake8-bugbear==22.1.11, importlib-metadata==4.12.0]
 - repo: https://github.com/asottile/blacken-docs
-  rev: v1.10.0
+  rev: v1.12.1
   hooks:
   - id: blacken-docs
-    additional_dependencies: [black==20.8b1]
+    additional_dependencies: [black==22.3.0]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,7 +3,7 @@ repos:
   rev: v2.31.0
   hooks:
   - id: pyupgrade
-    args: [--py36-plus]
+    args: [--py37-plus]
 - repo: https://github.com/python/black
   rev: 22.3.0
   hooks:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -30,6 +30,7 @@ jobs:
       - py37-marshmallow3
       - py38-marshmallow3
       - py39-marshmallow3
+      - py310-marshmallow3
 
       - py39-lowest
       - py39-marshmallowdev

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -27,7 +27,6 @@ jobs:
     toxenvs:
       - lint
 
-      - py36-marshmallow3
       - py37-marshmallow3
       - py38-marshmallow3
       - py39-marshmallow3

--- a/setup.py
+++ b/setup.py
@@ -59,7 +59,7 @@ setup(
     license="MIT",
     zip_safe=False,
     keywords="flask-marshmallow",
-    python_requires=">=3.6",
+    python_requires=">=3.7",
     classifiers=[
         "Development Status :: 4 - Beta",
         "Environment :: Web Environment",

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ EXTRAS_REQUIRE = {
         "flask-sqlalchemy",
         "marshmallow-sqlalchemy>=0.24.0",
     ],
-    "docs": ["marshmallow-sqlalchemy>=0.13.0", "Sphinx==3.5.4", "sphinx-issues==1.2.0"],
+    "docs": ["marshmallow-sqlalchemy>=0.13.0", "Sphinx==4.5.0", "sphinx-issues==3.0.1"],
     "lint": [
         "flake8==3.9.2",
         "flake8-bugbear==20.11.1",

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1,7 +1,7 @@
 import json
 
 from flask import Flask, url_for
-from werkzeug.wrappers import BaseResponse
+from werkzeug.wrappers import Response
 
 from flask_marshmallow import Marshmallow
 from tests.markers import flask_1_req
@@ -29,7 +29,7 @@ def test_schema(app, schemas, mockauthor):
 def test_jsonify_instance(app, schemas, mockauthor):
     s = schemas.AuthorSchema()
     resp = s.jsonify(mockauthor)
-    assert isinstance(resp, BaseResponse)
+    assert isinstance(resp, Response)
     assert resp.content_type == "application/json"
     obj = json.loads(resp.get_data(as_text=True))
     assert isinstance(obj, dict)
@@ -39,7 +39,7 @@ def test_jsonify_instance(app, schemas, mockauthor):
 def test_jsonify_collection(app, schemas, mockauthorlist):
     s = schemas.AuthorSchema()
     resp = s.jsonify(mockauthorlist, many=True)
-    assert isinstance(resp, BaseResponse)
+    assert isinstance(resp, Response)
     assert resp.content_type == "application/json"
     obj = json.loads(resp.get_data(as_text=True))
     assert isinstance(obj, list)
@@ -49,7 +49,7 @@ def test_jsonify_collection(app, schemas, mockauthorlist):
 def test_jsonify_collection_via_schema_attr(app, schemas, mockauthorlist):
     s = schemas.AuthorSchema(many=True)
     resp = s.jsonify(mockauthorlist)
-    assert isinstance(resp, BaseResponse)
+    assert isinstance(resp, Response)
     assert resp.content_type == "application/json"
     obj = json.loads(resp.get_data(as_text=True))
     assert isinstance(obj, list)

--- a/tests/test_sqla.py
+++ b/tests/test_sqla.py
@@ -1,7 +1,7 @@
 import pytest
 from flask import Flask, url_for
 from flask_sqlalchemy import SQLAlchemy
-from werkzeug.wrappers import BaseResponse
+from werkzeug.wrappers import Response
 
 from flask_marshmallow import Marshmallow
 from flask_marshmallow.sqla import HyperlinkRelated
@@ -130,7 +130,7 @@ class TestSQLAlchemy:
         assert book_result["author_id"] == book.author_id
 
         resp = author_schema.jsonify(author)
-        assert isinstance(resp, BaseResponse)
+        assert isinstance(resp, Response)
 
     @requires_sqlalchemyschema
     def test_can_declare_sqla_auto_schemas(self, extma, models, db):
@@ -168,7 +168,7 @@ class TestSQLAlchemy:
         assert book_result["author_id"] == book.author_id
 
         resp = author_schema.jsonify(author)
-        assert isinstance(resp, BaseResponse)
+        assert isinstance(resp, Response)
 
     @requires_sqlalchemyschema
     def test_hyperlink_related_field(self, extma, models, db, extapp):

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 envlist=
     lint
-    py{36,37,38,39}-marshmallow3
+    py{37,38,39,310}-marshmallow3
     py39-lowest
     py39-marshmallowdev
     docs


### PR DESCRIPTION
There is no 0.x next release branch and as such I have created this PR to dev (in conflict with the contributing guidelines)

It fixes errors in the pre commit linting caused by an exception in black 22.1.0 and a deprecation from importlib-metadata >= 5.

Hopefully this is useful and can be merged. 