### PR TITLE
Update pre-commit config

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,21 +1,21 @@
 repos:
 - repo: https://github.com/asottile/pyupgrade
-  rev: v2.31.0
+  rev: v3.3.1
   hooks:
   - id: pyupgrade
     args: [--py37-plus]
 - repo: https://github.com/python/black
-  rev: 22.3.0
+  rev: 23.1.0
   hooks:
   - id: black
     language_version: python3
-- repo: https://gitlab.com/pycqa/flake8
-  rev: 3.9.2
+- repo: https://github.com/pycqa/flake8
+  rev: 6.0.0
   hooks:
   - id: flake8
-    additional_dependencies: [flake8-bugbear==22.1.11, importlib-metadata==4.12.0]
+    additional_dependencies: [flake8-bugbear==23.1.20]
 - repo: https://github.com/asottile/blacken-docs
-  rev: v1.12.1
+  rev: 1.13.0
   hooks:
   - id: blacken-docs
-    additional_dependencies: [black==22.3.0]
+    additional_dependencies: [black==23.1.0]

--- a/setup.cfg
+++ b/setup.cfg
@@ -2,7 +2,7 @@
 universal = 1
 
 [flake8]
-ignore = E203, E266, E501, W503
+ignore = E203, E266, E501, W503, B907
 max-line-length = 110
 max-complexity = 18
 select = B,C,E,F,W,T4,B9

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -66,7 +66,6 @@ def book(id):
 
 @pytest.yield_fixture(scope="function")
 def app():
-
     ctx = _app.test_request_context()
     ctx.push()
 


### PR DESCRIPTION
- update from gitlab mirror for flake8 to latest
- pre-commit autoupdate & updadup
- remove dependency on importlib-metadata from flake8 hook
- apply changes from fixers (black modified whitespace)

After the above, flake8-bugbear was failing with B907. This is one of the opinionated warnings, and it's not fully accurate to the context of f-strings which are part of an external interface. As such, rather than make changes which could impact library consumers, suppress B907.