### PR TITLE
Catch warnings in tests & remove support for older URLFor argument syntax

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,11 @@ Changelog
 * Only support Python>=3.6, marshmallow>=3.0.0, and marshmallow-sqlalchemy>=0.24.0.
 * Add support for python3.11
 
+Bug fixes:
+
+* Address distutils deprecation warning in Python 3.10 (:pr:`242`).
+  Thanks :user:`GabrielLins64` for the PR.
+
 0.14.0 (2020-09-27)
 *******************
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,9 @@ Changelog
 
 * Only support Python>=3.6, marshmallow>=3.0.0, and marshmallow-sqlalchemy>=0.24.0.
 * Add support for python3.11
+* *Backwards-incompatible*: ``URLFor`` and ``AbsoluteURLFor`` now do not accept
+  parameters for ``flask.url_for`` as top-level parameters. They must always be
+  passed in the ``values`` dictionary, as explained in the v0.14.0 changelog.
 
 Bug fixes:
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -6,3 +6,12 @@ ignore = E203, E266, E501, W503, B907
 max-line-length = 110
 max-complexity = 18
 select = B,C,E,F,W,T4,B9
+
+[tool:pytest]
+filterwarnings =
+    # warnings are errors
+    error
+    # marshmallow-sqlalchemy triggers this on sqlalchemy 2.0
+    ignore:The Query\.get\(\) method is considered legacy:sqlalchemy.exc.LegacyAPIWarning
+    # marshmallow triggers this when we test on marshmallow version 3.0
+    ignore:distutils Version classes are deprecated\. Use packaging.version instead\.:DeprecationWarning:marshmallow

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ EXTRAS_REQUIRE = {
 EXTRAS_REQUIRE["tests"] = EXTRAS_REQUIRE["sqlalchemy"] + ["pytest", "mock"]
 EXTRAS_REQUIRE["dev"] = EXTRAS_REQUIRE["tests"] + EXTRAS_REQUIRE["lint"] + ["tox"]
 
-REQUIRES = ["Flask", "marshmallow>=3.0.0"]
+REQUIRES = ["Flask", "marshmallow>=3.0.0", "packaging>=17.0"]
 
 
 def find_version(fname):

--- a/src/flask_marshmallow/__init__.py
+++ b/src/flask_marshmallow/__init__.py
@@ -6,7 +6,7 @@
     with your Flask application.
 """
 import warnings
-from distutils.version import LooseVersion
+from packaging.version import Version
 
 from marshmallow import fields as base_fields, exceptions, pprint
 
@@ -30,7 +30,7 @@ else:
         has_sqla = True
 
 __version__ = "0.14.0"
-__version_info__ = tuple(LooseVersion(__version__).version)
+__version_info__ = Version(__version__).release
 __all__ = ["EXTENSION_NAME", "Marshmallow", "Schema", "fields", "exceptions", "pprint"]
 
 EXTENSION_NAME = "flask-marshmallow"

--- a/src/flask_marshmallow/fields.py
+++ b/src/flask_marshmallow/fields.py
@@ -80,9 +80,9 @@ class URLFor(fields.Field):
 
     _CHECK_ATTRIBUTE = False
 
-    def __init__(self, endpoint, values=None, **kwargs):
+    def __init__(self, endpoint, values=None, id=None, **kwargs):
         self.endpoint = endpoint
-        self.values = values or kwargs  # kwargs for backward compatibility
+        self.values = values or {}
         fields.Field.__init__(self, **kwargs)
 
     def _serialize(self, value, key, obj):
@@ -115,10 +115,10 @@ class AbsoluteURLFor(URLFor):
     """Field that outputs the absolute URL for an endpoint."""
 
     def __init__(self, endpoint, values=None, **kwargs):
-        if values:  # for backward compatibility
+        if values:
             values["_external"] = True
         else:
-            kwargs["_external"] = True
+            values = {"_external": True}
         URLFor.__init__(self, endpoint=endpoint, values=values, **kwargs)
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,7 +1,7 @@
 """Pytest fixtures for the test suite."""
+import pytest
 from flask import Flask
 from flask_marshmallow import Marshmallow
-import pytest
 
 _app = Flask(__name__)
 _app.testing = True
@@ -64,7 +64,7 @@ def book(id):
     return "Legend of Bagger Vance"
 
 
-@pytest.yield_fixture(scope="function")
+@pytest.fixture(scope="function")
 def app():
     ctx = _app.test_request_context()
     ctx.push()
@@ -85,10 +85,13 @@ def schemas(ma):
         class Meta:
             fields = ("id", "name", "absolute_url", "links")
 
-        absolute_url = ma.AbsoluteURLFor("author", id="<id>")
+        absolute_url = ma.AbsoluteURLFor("author", values={"id": "<id>"})
 
         links = ma.Hyperlinks(
-            {"self": ma.URLFor("author", id="<id>"), "collection": ma.URLFor("authors")}
+            {
+                "self": ma.URLFor("author", values={"id": "<id>"}),
+                "collection": ma.URLFor("authors"),
+            }
         )
 
     class BookSchema(ma.Schema):
@@ -98,7 +101,10 @@ def schemas(ma):
         author = ma.Nested(AuthorSchema)
 
         links = ma.Hyperlinks(
-            {"self": ma.URLFor("book", id="<id>"), "collection": ma.URLFor("books")}
+            {
+                "self": ma.URLFor("book", values={"id": "<id>"}),
+                "collection": ma.URLFor("books"),
+            }
         )
 
     # So we can access schemas.AuthorSchema, etc.

--- a/tests/markers.py
+++ b/tests/markers.py
@@ -1,9 +1,9 @@
 import pytest
 import flask
-from distutils.version import LooseVersion
+from packaging.version import Version
 
 
-flask_version = LooseVersion(flask.__version__)
+flask_version = Version(flask.__version__)
 flask_1_req = pytest.mark.skipif(
-    flask_version < LooseVersion("0.11"), reason="flask 0.11 or higher required"
+    flask_version < Version("0.11"), reason="flask 0.11 or higher required"
 )

--- a/tests/test_sqla.py
+++ b/tests/test_sqla.py
@@ -22,7 +22,7 @@ requires_sqlalchemyschema = pytest.mark.skipif(
 
 
 class TestSQLAlchemy:
-    @pytest.yield_fixture()
+    @pytest.fixture
     def extapp(self):
         app_ = Flask("extapp")
         app_.testing = True
@@ -46,15 +46,15 @@ class TestSQLAlchemy:
 
         ctx.pop()
 
-    @pytest.fixture()
+    @pytest.fixture
     def db(self, extapp):
-        return extapp.extensions["sqlalchemy"].db
+        return extapp.extensions["sqlalchemy"]
 
-    @pytest.fixture()
+    @pytest.fixture
     def extma(self, extapp):
         return extapp.extensions["flask-marshmallow"]
 
-    @pytest.yield_fixture()
+    @pytest.fixture
     def models(self, db):
         class AuthorModel(db.Model):
             __tablename__ = "author"


### PR DESCRIPTION
I've rebased this off of #243 to pick up the latest changes and resolve conflicts and added an additional changeset. My added change sets `filterwarnings = error` and deals with the consequences of that setting.

---

[Apply filterwarnings = error to tests and update](https://github.com/marshmallow-code/flask-marshmallow/commit/a3a970fcecc46f4c44f0d9e8ddaa66b00e0dae69) 

This applies the error filter to force test failures on warnings, and does the necessary cleanup. Primarily, that means identifying the two classes of `ignore:` rules which are necessary to handle cases outside of this library's control. Secondarily, it forces the deprecation of the older url_for field specification syntax, which cannot be supported cleanly. Since this was deprecated in the last release, it is presumably safe to remove it, but the change is still noted as breaking in the changelog.