### PR TITLE
Bump marshmallow-sqlalchemy and suppress a warning

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -3,7 +3,7 @@ sphinx:
   configuration: docs/conf.py
 formats: all
 python:
-  version: 3.8
+  version: "3.8"
   install:
     - method: pip
       path: .

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,7 +4,8 @@ Changelog
 0.15.0 (unreleased)
 *******************
 
-* Only support Python>=3.6, marshmallow>=3.0.0, and marshmallow-sqlalchemy>=0.24.0.
+* Only support Python>=3.6, marshmallow>=3.0.0, and
+  marshmallow-sqlalchemy>=0.28.2
 * Add support for python3.11
 * *Backwards-incompatible*: ``URLFor`` and ``AbsoluteURLFor`` now do not accept
   parameters for ``flask.url_for`` as top-level parameters. They must always be

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import find_packages, setup
 EXTRAS_REQUIRE = {
     "sqlalchemy": [
         "flask-sqlalchemy>=3.0.0",
-        "marshmallow-sqlalchemy>=0.24.0",
+        "marshmallow-sqlalchemy>=0.28.2",
     ],
     "docs": ["marshmallow-sqlalchemy>=0.13.0", "Sphinx==4.5.0", "sphinx-issues==3.0.1"],
 }

--- a/tests/test_sqla.py
+++ b/tests/test_sqla.py
@@ -170,7 +170,13 @@ class TestSQLAlchemy:
         resp = author_schema.jsonify(author)
         assert isinstance(resp, Response)
 
+    # FIXME: temporarily filter out this warning
+    # this is triggered by marshmallow-sqlalchemy on sqlalchemy v1.4.x on the current version
+    # it should be fixed in an upcoming marshmallow-sqlalchemy release
     @requires_sqlalchemyschema
+    @pytest.mark.filterwarnings(
+        "ignore:Deprecated API features detected:sqlalchemy.exc.LegacyAPIWarning"
+    )
     def test_hyperlink_related_field(self, extma, models, db, extapp):
         class BookSchema(extma.SQLAlchemySchema):
             class Meta:


### PR DESCRIPTION
This is a move towards better compatibility with sqlalchemy 1.4 / 2.0

Because marshmallow-sqlalchemy has several changes and fixes over its version range to be compatible with the newer sqlalchemy versions, push towards the latest version.

Ignore the one warning in the build which we can't get away from right now. (Requires marshmallow-sqlalchemy v0.29.0, not yet released.)

---

I'm trying to get the build sorted out before I work on a release.