### PR TITLE
Add Config field for dumping Flask configuration values

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,12 +4,16 @@ Changelog
 0.16.0 (unreleased)
 *******************
 
+Features:
+
+* Add field ``Config`` for serializing Flask configuration values (:issue:`280`, :pr:`281`).
+  Thanks :user:`greyli` for the PR.
+
 Support:
 
 * Support marshmallow-sqlalchemy>=0.29.0.
 * Test against Python 3.12.
 * Drop support for Python 3.7.
-* Add field ``Config`` for Flask configuration value.
 
 0.15.0 (2023-04-05)
 *******************

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -9,6 +9,7 @@ Support:
 * Support marshmallow-sqlalchemy>=0.29.0.
 * Test against Python 3.12.
 * Drop support for Python 3.7.
+* Add field ``Config`` for Flask configuration value.
 
 0.15.0 (2023-04-05)
 *******************

--- a/src/flask_marshmallow/fields.py
+++ b/src/flask_marshmallow/fields.py
@@ -202,7 +202,7 @@ class Config(fields.Field):
             user = String()
             title = Config('API_TITLE')
 
-    This field should only be used in an output schema. The ``ValueError`` will
+    This field should only be used in an output schema. A ``ValueError`` will
     be raised if the config key is not found in the app config.
 
     :param str key: The key of the configuration value.
@@ -216,5 +216,5 @@ class Config(fields.Field):
 
     def _serialize(self, value, attr, obj, **kwargs):
         if self.key not in current_app.config:
-            raise ValueError(f"The key {self.key} is not found in the app config.")
+            raise ValueError(f"The key {self.key!r} is not found in the app config.")
         return current_app.config[self.key]

--- a/src/flask_marshmallow/fields.py
+++ b/src/flask_marshmallow/fields.py
@@ -10,11 +10,19 @@
 import re
 
 from flask import url_for
+from flask import current_app
 from marshmallow import fields
 from marshmallow import missing
 
 
-__all__ = ["URLFor", "UrlFor", "AbsoluteURLFor", "AbsoluteUrlFor", "Hyperlinks"]
+__all__ = [
+    "URLFor",
+    "UrlFor",
+    "AbsoluteURLFor",
+    "AbsoluteUrlFor",
+    "Hyperlinks",
+    "Config",
+]
 
 
 _tpl_pattern = re.compile(r"\s*<\s*(\S*)\s*>\s*")
@@ -178,3 +186,35 @@ class Hyperlinks(fields.Field):
 
     def _serialize(self, value, attr, obj):
         return _rapply(self.schema, _url_val, key=attr, obj=obj)
+
+
+class Config(fields.Field):
+    """A field for Flask configuration values.
+
+    Examples: ::
+
+        from flask import Flask
+
+        app = Flask(__name__)
+        app.config['API_TITLE'] = 'Pet API'
+
+        class FooSchema(Schema):
+            user = String()
+            title = Config('API_TITLE')
+
+    This field should only be used in an output schema. The ``ValueError`` will
+    be raised if the config key is not found in the app config.
+
+    :param str key: The key of the configuration value.
+    """
+
+    _CHECK_ATTRIBUTE = False
+
+    def __init__(self, key, **kwargs):
+        fields.Field.__init__(self, **kwargs)
+        self.key = key
+
+    def _serialize(self, value, attr, obj, **kwargs):
+        if self.key not in current_app.config:
+            raise ValueError(f"The key {self.key} is not found in the app config.")
+        return current_app.config[self.key]

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -137,3 +137,11 @@ def test_aliases(ma):
 
     assert UrlFor is URLFor
     assert AbsoluteUrlFor is AbsoluteURLFor
+
+
+def test_config_field(ma, app, mockauthor):
+    app.config["NAME"] = "test"
+    field = ma.Config(key="NAME")
+
+    result = field.serialize("config_value", mockauthor)
+    assert result == "test"

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -145,3 +145,7 @@ def test_config_field(ma, app, mockauthor):
 
     result = field.serialize("config_value", mockauthor)
     assert result == "test"
+
+    field = ma.Config(key="DOES_NOT_EXIST")
+    with pytest.raises(ValueError, match="not found in the app config"):
+        field.serialize("config_value", mockauthor)


### PR DESCRIPTION
Migrate the `Config `field from APIFlask (#280).

Example usage:

```py
from flask import Flask

app = Flask(__name__)
app.config['API_TITLE'] = 'Pet API'

class FooSchema(Schema):
    user = String()
    title = Config('API_TITLE')
```