### PR TITLE
feat: File field and validators

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -3,11 +3,12 @@ Changelog
 
 0.16.0 (unreleased)
 *******************
-* Add field ``File`` for uploaded File.
-* Add `FileType` and `FileSize` validation classes.
 
 Features:
 
+* Add field ``fields.File``, ``validate.FileType``, and ``validate.FileSize`` 
+  for deserializing uploaded files (:issue:`280`, :pr:`282`).
+  Thanks :user:`uncle-lv` for the PR
 * Add field ``Config`` for serializing Flask configuration values (:issue:`280`, :pr:`281`).
   Thanks :user:`greyli` for the PR.
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -3,6 +3,8 @@ Changelog
 
 0.16.0 (unreleased)
 *******************
+* Add field ``File`` for uploaded File.
+* Add `FileType` and `FileSize` validation classes.
 
 Support:
 
@@ -33,8 +35,8 @@ Bug fixes:
 *******************
 
 * Add ``values`` argument to ``URLFor`` and ``AbsoluteURLFor`` for passing values to ``flask.url_for``.
- This prevents unrelated parameters from getting passed (:issue:`52`, :issue:`67`).
- Thanks :user:`AlrasheedA` for the PR.
+  This prevents unrelated parameters from getting passed (:issue:`52`, :issue:`67`).
+  Thanks :user:`AlrasheedA` for the PR.
 
 Deprecation:
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -229,6 +229,9 @@ API
 .. automodule:: flask_marshmallow.fields
     :members:
 
+.. automodule:: flask_marshmallow.validate
+    :members:
+
 .. automodule:: flask_marshmallow.sqla
     :members:
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -178,6 +178,7 @@ You can now use your schema to dump and load your ORM objects.
 
 - By default, `~flask_marshmallow.sqla.SQLAlchemySchema` uses the scoped session created by Flask-SQLAlchemy.
 - `~flask_marshmallow.sqla.SQLAlchemySchema` subclasses `flask_marshmallow.Schema`, so it includes the `~flask_marshmallow.Schema.jsonify` method.
+
 Note: By default, Flask's `jsonify` method sorts the list of keys and returns consistent results to ensure that external HTTP caches aren't trashed. As a side effect, this will override `ordered=True <https://marshmallow.readthedocs.io/en/latest/quickstart.html#ordering-output>`_ 
 in the SQLAlchemySchema's `class Meta` (if you set it). To disable this, set `JSON_SORT_KEYS=False` in your Flask app config. In production it's recommended to let `jsonify` sort the keys and not set `ordered=True` in your `~flask_marshmallow.sqla.SQLAlchemySchema` in order to minimize generation time and maximize cacheability of the results.
 

--- a/src/flask_marshmallow/__init__.py
+++ b/src/flask_marshmallow/__init__.py
@@ -32,7 +32,15 @@ else:
 
 __version__ = "0.15.0"
 __version_info__ = Version(__version__).release
-__all__ = ["EXTENSION_NAME", "Marshmallow", "Schema", "fields", "exceptions", "pprint"]
+__all__ = [
+    "EXTENSION_NAME",
+    "Marshmallow",
+    "Schema",
+    "fields",
+    "exceptions",
+    "pprint",
+    "validate",
+]
 
 EXTENSION_NAME = "flask-marshmallow"
 

--- a/src/flask_marshmallow/fields.py
+++ b/src/flask_marshmallow/fields.py
@@ -14,7 +14,7 @@ from marshmallow import fields
 from marshmallow import missing
 
 
-__all__ = ["URLFor", "UrlFor", "AbsoluteURLFor", "AbsoluteUrlFor", "Hyperlinks"]
+__all__ = ["URLFor", "UrlFor", "AbsoluteURLFor", "AbsoluteUrlFor", "Hyperlinks", "File"]
 
 
 _tpl_pattern = re.compile(r"\s*<\s*(\S*)\s*>\s*")
@@ -178,3 +178,27 @@ class Hyperlinks(fields.Field):
 
     def _serialize(self, value, attr, obj):
         return _rapply(self.schema, _url_val, key=attr, obj=obj)
+
+
+class File(fields.Field):
+    """A binary file field for uploaded files.
+
+    Examples: ::
+
+        class ImageSchema(Schema):
+            image = File(required=True)
+    """
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.metadata["type"] = "string"
+        self.metadata["format"] = "binary"
+
+    default_error_messages = {"invalid": "Not a valid file."}
+
+    def _deserialize(self, value, attr, data, **kwargs):
+        from werkzeug.datastructures import FileStorage
+
+        if not isinstance(value, FileStorage):
+            raise self.make_error("invalid")
+        return value

--- a/src/flask_marshmallow/fields.py
+++ b/src/flask_marshmallow/fields.py
@@ -200,6 +200,7 @@ class File(fields.Field):
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
+        # Metadata used by apispec
         self.metadata["type"] = "string"
         self.metadata["format"] = "binary"
 
@@ -235,7 +236,7 @@ class Config(fields.Field):
 
     _CHECK_ATTRIBUTE = False
 
-    def __init__(self, key, **kwargs):
+    def __init__(self, key: str, **kwargs):
         fields.Field.__init__(self, **kwargs)
         self.key = key
 

--- a/src/flask_marshmallow/validate.py
+++ b/src/flask_marshmallow/validate.py
@@ -2,10 +2,11 @@
     flask_marshmallow.validate
     ~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-    Custom, validation classes for various types of data.
+    Custom validation classes for various types of data.
 """
 import os
 import re
+import typing
 
 from marshmallow.exceptions import ValidationError
 from marshmallow.validate import Validator as Validator
@@ -21,7 +22,7 @@ def _get_filestorage_size(file):
 
 # This function is copied from loguru with few modifications.
 # https://github.com/Delgan/loguru/blob/master/loguru/_string_parsers.py#L35
-def _parse_size(size):
+def _parse_size(size: str) -> float:
     """Return the value which the ``size`` represents in bytes."""
     size = size.strip()
     reg = re.compile(r"([e\+\-\.\d]+)\s*([kmgtpezy])?(i)?(b)", flags=re.I)
@@ -41,9 +42,7 @@ def _parse_size(size):
     u = "kmgtpezy".index(u.lower()) + 1 if u else 0
     i = 1024 if i else 1000
     b = {"b": 8, "B": 1}[b] if b else 1
-    size: float = s * i**u / b
-
-    return size
+    return s * i**u / b
 
 
 class FileSize(Validator):
@@ -56,6 +55,7 @@ class FileSize(Validator):
     or is specified as `True`, then the ``max`` bound is included in the range.
 
     Example: ::
+
         class ImageSchema(Schema):
             image = File(required=True, validate=FileSize(min='1 MiB', max='2 MiB'))
 
@@ -81,11 +81,11 @@ class FileSize(Validator):
 
     def __init__(
         self,
-        min=None,
-        max=None,
-        min_inclusive=True,
-        max_inclusive=True,
-        error=None,
+        min: str | None = None,
+        max: str | None = None,
+        min_inclusive: bool = True,
+        max_inclusive: bool = True,
+        error: str | None = None,
     ):
         self.min = min
         self.max = max
@@ -158,8 +158,8 @@ class FileType(Validator):
 
     def __init__(
         self,
-        accept,
-        error=None,
+        accept: typing.Iterable[str],
+        error: str | None = None,
     ):
         self.allowed_types = {ext.lower() for ext in accept}
         self.error = error or self.default_message

--- a/src/flask_marshmallow/validate.py
+++ b/src/flask_marshmallow/validate.py
@@ -1,0 +1,181 @@
+"""
+    flask_marshmallow.validate
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+    Custom, validation classes for various types of data.
+"""
+import os
+import re
+
+from marshmallow.exceptions import ValidationError
+from marshmallow.validate import Validator as Validator
+from werkzeug.datastructures import FileStorage
+
+
+def _get_filestorage_size(file):
+    """Return the size of the FileStorage object in bytes.
+    """
+    size = len(file.read())
+    file.stream.seek(0)
+    return size
+
+
+# This function is copied from loguru with few modifications.
+# https://github.com/Delgan/loguru/blob/master/loguru/_string_parsers.py#L35
+def _parse_size(size):
+    """Return the value which the ``size`` represents in bytes.
+    """
+    size = size.strip()
+    reg = re.compile(r'([e\+\-\.\d]+)\s*([kmgtpezy])?(i)?(b)', flags=re.I)
+
+    match = reg.fullmatch(size)
+
+    if not match:
+        raise ValueError(f"Invalid size value: '{size!r}'")
+
+    s, u, i, b = match.groups()
+
+    try:
+        s = float(s)
+    except ValueError as e:
+        raise ValueError(f"Invalid float value while parsing size: '{s!r}'") from e
+
+    u = 'kmgtpezy'.index(u.lower()) + 1 if u else 0
+    i = 1024 if i else 1000
+    b = {'b': 8, 'B': 1}[b] if b else 1
+    size: float = s * i**u / b
+
+    return size
+
+
+class FileSize(Validator):
+    """Validator which succeeds if the file passed to it is within the specified
+    size range. If ``min`` is not specified, or is specified as `None`,
+    no lower bound exists. If ``max`` is not specified, or is specified as `None`,
+    no upper bound exists. The inclusivity of the bounds (if they exist) is configurable.
+    If ``min_inclusive`` is not specified, or is specified as `True`, then
+    the ``min`` bound is included in the range. If ``max_inclusive`` is not specified,
+    or is specified as `True`, then the ``max`` bound is included in the range.
+
+    Example: ::
+        class ImageSchema(Schema):
+            image = File(required=True, validate=FileSize(min='1 MiB', max='2 MiB'))
+
+    Arguments:
+        min: The minimum size (lower bound). If not provided, minimum
+            size will not be checked.
+        max: The maximum size (upper bound). If not provided, maximum
+            size will not be checked.
+        min_inclusive: Whether the `min` bound is included in the range.
+        max_inclusive: Whether the `max` bound is included in the range.
+        error: Error message to raise in case of a validation error.
+            Can be interpolated with `{input}`, `{min}` and `{max}`.
+    """
+
+    message_min = 'Must be {min_op} {{min}}.'
+    message_max = 'Must be {max_op} {{max}}.'
+    message_all = 'Must be {min_op} {{min}} and {max_op} {{max}}.'
+
+    message_gte = 'greater than or equal to'
+    message_gt = 'greater than'
+    message_lte = 'less than or equal to'
+    message_lt = 'less than'
+
+    def __init__(
+        self,
+        min=None,
+        max=None,
+        min_inclusive=True,
+        max_inclusive=True,
+        error=None,
+    ):
+        self.min = min
+        self.max = max
+        self.min_size = _parse_size(self.min) if self.min else None
+        self.max_size = _parse_size(self.max) if self.max else None
+        self.min_inclusive = min_inclusive
+        self.max_inclusive = max_inclusive
+        self.error = error
+
+        self.message_min = self.message_min.format(
+            min_op=self.message_gte if self.min_inclusive else self.message_gt
+        )
+        self.message_max = self.message_max.format(
+            max_op=self.message_lte if self.max_inclusive else self.message_lt
+        )
+        self.message_all = self.message_all.format(
+            min_op=self.message_gte if self.min_inclusive else self.message_gt,
+            max_op=self.message_lte if self.max_inclusive else self.message_lt,
+        )
+
+    def _repr_args(self):
+        return 'min={!r}, max={!r}, min_inclusive={!r}, max_inclusive={!r}'.format(
+            self.min, self.max, self.min_inclusive, self.max_inclusive
+        )
+
+    def _format_error(self, value, message):
+        return (self.error or message).format(input=value, min=self.min, max=self.max)
+
+    def __call__(self, value):
+        if not isinstance(value, FileStorage):
+            raise TypeError(
+                f'A FileStorage object is required, not {type(value).__name__!r}'
+            )
+
+        file_size = _get_filestorage_size(value)
+        if self.min_size is not None and (
+            file_size < self.min_size if self.min_inclusive else file_size <= self.min_size
+        ):
+            message = self.message_min if self.max is None else self.message_all
+            raise ValidationError(self._format_error(value, message))
+
+        if self.max_size is not None and (
+            file_size > self.max_size if self.max_inclusive else file_size >= self.max_size
+        ):
+            message = self.message_max if self.min is None else self.message_all
+            raise ValidationError(self._format_error(value, message))
+
+        return value
+
+
+class FileType(Validator):
+    """Validator which succeeds if the uploaded file is allowed by a given list
+        of extensions.
+
+    Example: ::
+        class ImageSchema(Schema):
+            image = File(required=True, validate=FileType(['.png']))
+
+    Arguments:
+        accept: A sequence of allowed extensions.
+        error: Error message to raise in case of a validation error.
+            Can be interpolated with `{input}` and `{extensions}`.
+    """
+
+    default_message = 'Not an allowed file type. Allowed file types: [{extensions}]'
+
+    def __init__(
+        self,
+        accept,
+        error=None,
+    ):
+        self.allowed_types = {ext.lower() for ext in accept}
+        self.error = error or self.default_message
+
+    def _format_error(self, value):
+        return (self.error or self.default_message).format(
+            input=value,
+            extensions=''.join(self.allowed_types)
+        )
+
+    def __call__(self, value):
+        if not isinstance(value, FileStorage):
+            raise TypeError(
+                f'A FileStorage object is required, not {type(value).__name__!r}'
+            )
+
+        _, extension = os.path.splitext(value.filename) if value.filename else (None, None)
+        if extension is None or extension.lower() not in self.allowed_types:
+            raise ValidationError(self._format_error(value))
+
+        return value

--- a/src/flask_marshmallow/validate.py
+++ b/src/flask_marshmallow/validate.py
@@ -13,8 +13,7 @@ from werkzeug.datastructures import FileStorage
 
 
 def _get_filestorage_size(file):
-    """Return the size of the FileStorage object in bytes.
-    """
+    """Return the size of the FileStorage object in bytes."""
     size = len(file.read())
     file.stream.seek(0)
     return size
@@ -23,10 +22,9 @@ def _get_filestorage_size(file):
 # This function is copied from loguru with few modifications.
 # https://github.com/Delgan/loguru/blob/master/loguru/_string_parsers.py#L35
 def _parse_size(size):
-    """Return the value which the ``size`` represents in bytes.
-    """
+    """Return the value which the ``size`` represents in bytes."""
     size = size.strip()
-    reg = re.compile(r'([e\+\-\.\d]+)\s*([kmgtpezy])?(i)?(b)', flags=re.I)
+    reg = re.compile(r"([e\+\-\.\d]+)\s*([kmgtpezy])?(i)?(b)", flags=re.I)
 
     match = reg.fullmatch(size)
 
@@ -40,9 +38,9 @@ def _parse_size(size):
     except ValueError as e:
         raise ValueError(f"Invalid float value while parsing size: '{s!r}'") from e
 
-    u = 'kmgtpezy'.index(u.lower()) + 1 if u else 0
+    u = "kmgtpezy".index(u.lower()) + 1 if u else 0
     i = 1024 if i else 1000
-    b = {'b': 8, 'B': 1}[b] if b else 1
+    b = {"b": 8, "B": 1}[b] if b else 1
     size: float = s * i**u / b
 
     return size
@@ -72,14 +70,14 @@ class FileSize(Validator):
             Can be interpolated with `{input}`, `{min}` and `{max}`.
     """
 
-    message_min = 'Must be {min_op} {{min}}.'
-    message_max = 'Must be {max_op} {{max}}.'
-    message_all = 'Must be {min_op} {{min}} and {max_op} {{max}}.'
+    message_min = "Must be {min_op} {{min}}."
+    message_max = "Must be {max_op} {{max}}."
+    message_all = "Must be {min_op} {{min}} and {max_op} {{max}}."
 
-    message_gte = 'greater than or equal to'
-    message_gt = 'greater than'
-    message_lte = 'less than or equal to'
-    message_lt = 'less than'
+    message_gte = "greater than or equal to"
+    message_gt = "greater than"
+    message_lte = "less than or equal to"
+    message_lt = "less than"
 
     def __init__(
         self,
@@ -109,7 +107,7 @@ class FileSize(Validator):
         )
 
     def _repr_args(self):
-        return 'min={!r}, max={!r}, min_inclusive={!r}, max_inclusive={!r}'.format(
+        return "min={!r}, max={!r}, min_inclusive={!r}, max_inclusive={!r}".format(
             self.min, self.max, self.min_inclusive, self.max_inclusive
         )
 
@@ -119,18 +117,22 @@ class FileSize(Validator):
     def __call__(self, value):
         if not isinstance(value, FileStorage):
             raise TypeError(
-                f'A FileStorage object is required, not {type(value).__name__!r}'
+                f"A FileStorage object is required, not {type(value).__name__!r}"
             )
 
         file_size = _get_filestorage_size(value)
         if self.min_size is not None and (
-            file_size < self.min_size if self.min_inclusive else file_size <= self.min_size
+            file_size < self.min_size
+            if self.min_inclusive
+            else file_size <= self.min_size
         ):
             message = self.message_min if self.max is None else self.message_all
             raise ValidationError(self._format_error(value, message))
 
         if self.max_size is not None and (
-            file_size > self.max_size if self.max_inclusive else file_size >= self.max_size
+            file_size > self.max_size
+            if self.max_inclusive
+            else file_size >= self.max_size
         ):
             message = self.message_max if self.min is None else self.message_all
             raise ValidationError(self._format_error(value, message))
@@ -152,7 +154,7 @@ class FileType(Validator):
             Can be interpolated with `{input}` and `{extensions}`.
     """
 
-    default_message = 'Not an allowed file type. Allowed file types: [{extensions}]'
+    default_message = "Not an allowed file type. Allowed file types: [{extensions}]"
 
     def __init__(
         self,
@@ -164,17 +166,18 @@ class FileType(Validator):
 
     def _format_error(self, value):
         return (self.error or self.default_message).format(
-            input=value,
-            extensions=''.join(self.allowed_types)
+            input=value, extensions="".join(self.allowed_types)
         )
 
     def __call__(self, value):
         if not isinstance(value, FileStorage):
             raise TypeError(
-                f'A FileStorage object is required, not {type(value).__name__!r}'
+                f"A FileStorage object is required, not {type(value).__name__!r}"
             )
 
-        _, extension = os.path.splitext(value.filename) if value.filename else (None, None)
+        _, extension = (
+            os.path.splitext(value.filename) if value.filename else (None, None)
+        )
         if extension is None or extension.lower() not in self.allowed_types:
             raise ValidationError(self._format_error(value))
 

--- a/src/flask_marshmallow/validate.py
+++ b/src/flask_marshmallow/validate.py
@@ -81,11 +81,11 @@ class FileSize(Validator):
 
     def __init__(
         self,
-        min: str | None = None,
-        max: str | None = None,
+        min: typing.Optional[str] = None,
+        max: typing.Optional[str] = None,
         min_inclusive: bool = True,
         max_inclusive: bool = True,
-        error: str | None = None,
+        error: typing.Optional[str] = None,
     ):
         self.min = min
         self.max = max
@@ -159,7 +159,7 @@ class FileType(Validator):
     def __init__(
         self,
         accept: typing.Iterable[str],
-        error: str | None = None,
+        error: typing.Optional[str] = None,
     ):
         self.allowed_types = {ext.lower() for ext in accept}
         self.error = error or self.default_message

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -1,7 +1,11 @@
+import io
+
 import pytest
 from flask import url_for
 from flask_marshmallow.fields import _tpl
+from marshmallow.exceptions import ValidationError
 from werkzeug.routing import BuildError
+from werkzeug.datastructures import FileStorage
 
 
 @pytest.mark.parametrize(
@@ -137,3 +141,16 @@ def test_aliases(ma):
 
     assert UrlFor is URLFor
     assert AbsoluteUrlFor is AbsoluteURLFor
+
+
+def test_file_field(ma, mockauthor):
+    field = ma.File()
+    fs = FileStorage(io.BytesIO(b"test"), "test.jpg")
+    result = field.deserialize(fs, mockauthor)
+    assert result == fs
+
+    with pytest.raises(ValidationError, match="Field may not be null."):
+        field.deserialize(None, mockauthor)
+
+    with pytest.raises(ValidationError, match="Not a valid file."):
+        field.deserialize("123", mockauthor)

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -8,39 +8,47 @@ from flask_marshmallow import validate
 
 
 def test_filesize_min():
-    fs = FileStorage(io.BytesIO(b''.ljust(1024)))
-    assert validate.FileSize(min='1 KiB', max='2 KiB')(fs) is fs
-    assert validate.FileSize(min='0 KiB', max='1 KiB')(fs) is fs
+    fs = FileStorage(io.BytesIO(b"".ljust(1024)))
+    assert validate.FileSize(min="1 KiB", max="2 KiB")(fs) is fs
+    assert validate.FileSize(min="0 KiB", max="1 KiB")(fs) is fs
     assert validate.FileSize()(fs) is fs
     assert validate.FileSize(min_inclusive=False, max_inclusive=False)(fs) is fs
-    assert validate.FileSize(min='1 KiB', max='1 KiB')(fs) is fs
+    assert validate.FileSize(min="1 KiB", max="1 KiB")(fs) is fs
 
-    with pytest.raises(ValidationError, match='Must be greater than or equal to 2 KiB'):
-        validate.FileSize(min='2 KiB', max='3 KiB')(fs)
-    with pytest.raises(ValidationError, match='Must be greater than or equal to 2 KiB'):
-        validate.FileSize(min='2 KiB')(fs)
-    with pytest.raises(ValidationError, match='Must be greater than 1 KiB'):
-        validate.FileSize(min='1 KiB', max='2 KiB', min_inclusive=False, max_inclusive=True)(fs)
-    with pytest.raises(ValidationError, match='less than 1 KiB'):
-        validate.FileSize(min='1 KiB', max='1 KiB', min_inclusive=True, max_inclusive=False)(fs)
+    with pytest.raises(ValidationError, match="Must be greater than or equal to 2 KiB"):
+        validate.FileSize(min="2 KiB", max="3 KiB")(fs)
+    with pytest.raises(ValidationError, match="Must be greater than or equal to 2 KiB"):
+        validate.FileSize(min="2 KiB")(fs)
+    with pytest.raises(ValidationError, match="Must be greater than 1 KiB"):
+        validate.FileSize(
+            min="1 KiB", max="2 KiB", min_inclusive=False, max_inclusive=True
+        )(fs)
+    with pytest.raises(ValidationError, match="less than 1 KiB"):
+        validate.FileSize(
+            min="1 KiB", max="1 KiB", min_inclusive=True, max_inclusive=False
+        )(fs)
 
 
 def test_filesize_max():
-    fs = FileStorage(io.BytesIO(b''.ljust(2048)))
-    assert validate.FileSize(min='1 KiB', max='2 KiB')(fs) is fs
-    assert validate.FileSize(max='2 KiB')(fs) is fs
+    fs = FileStorage(io.BytesIO(b"".ljust(2048)))
+    assert validate.FileSize(min="1 KiB", max="2 KiB")(fs) is fs
+    assert validate.FileSize(max="2 KiB")(fs) is fs
     assert validate.FileSize()(fs) is fs
     assert validate.FileSize(min_inclusive=False, max_inclusive=False)(fs) is fs
-    assert validate.FileSize(min='2 KiB', max='2 KiB')(fs) is fs
+    assert validate.FileSize(min="2 KiB", max="2 KiB")(fs) is fs
 
-    with pytest.raises(ValidationError, match='less than or equal to 1 KiB'):
-        validate.FileSize(min='0 KiB', max='1 KiB')(fs)
-    with pytest.raises(ValidationError, match='less than or equal to 1 KiB'):
-        validate.FileSize(max='1 KiB')(fs)
-    with pytest.raises(ValidationError, match='less than 2 KiB'):
-        validate.FileSize(min='1 KiB', max='2 KiB', min_inclusive=True, max_inclusive=False)(fs)
-    with pytest.raises(ValidationError, match='greater than 2 KiB'):
-        validate.FileSize(min='2 KiB', max='2 KiB', min_inclusive=False, max_inclusive=True)(fs)
+    with pytest.raises(ValidationError, match="less than or equal to 1 KiB"):
+        validate.FileSize(min="0 KiB", max="1 KiB")(fs)
+    with pytest.raises(ValidationError, match="less than or equal to 1 KiB"):
+        validate.FileSize(max="1 KiB")(fs)
+    with pytest.raises(ValidationError, match="less than 2 KiB"):
+        validate.FileSize(
+            min="1 KiB", max="2 KiB", min_inclusive=True, max_inclusive=False
+        )(fs)
+    with pytest.raises(ValidationError, match="greater than 2 KiB"):
+        validate.FileSize(
+            min="2 KiB", max="2 KiB", min_inclusive=False, max_inclusive=True
+        )(fs)
 
 
 def test_filesize_repr():
@@ -50,43 +58,50 @@ def test_filesize_repr():
                 min=None, max=None, error=None, min_inclusive=True, max_inclusive=True
             )
         )
-        == '<FileSize(min=None, max=None, min_inclusive=True, max_inclusive=True, error=None)>'
+        == "<FileSize(min=None, max=None, min_inclusive=True, max_inclusive=True, error=None)>"
     )
 
-    assert repr(
-        validate.FileSize(
-            min='1 KiB', max='3 KiB', error='foo', min_inclusive=False, max_inclusive=False
+    assert (
+        repr(
+            validate.FileSize(
+                min="1 KiB",
+                max="3 KiB",
+                error="foo",
+                min_inclusive=False,
+                max_inclusive=False,
+            )
         )
-    ) == "<FileSize(min='1 KiB', max='3 KiB', min_inclusive=False, max_inclusive=False, error='foo')>"  # noqa: E501
+        == "<FileSize(min='1 KiB', max='3 KiB', min_inclusive=False, max_inclusive=False, error='foo')>"
+    )  # noqa: E501
 
 
 def test_filesize_wrongtype():
-    with pytest.raises(TypeError, match='A FileStorage object is required, not '):
+    with pytest.raises(TypeError, match="A FileStorage object is required, not "):
         validate.FileSize()(1)
 
 
 def test_filetype():
-    png_fs = FileStorage(io.BytesIO(b''.ljust(1024)), 'test.png')
-    assert validate.FileType(['.png'])(png_fs) is png_fs
-    assert validate.FileType(['.PNG'])(png_fs) is png_fs
+    png_fs = FileStorage(io.BytesIO(b"".ljust(1024)), "test.png")
+    assert validate.FileType([".png"])(png_fs) is png_fs
+    assert validate.FileType([".PNG"])(png_fs) is png_fs
 
-    PNG_fs = FileStorage(io.BytesIO(b''.ljust(1024)), 'test.PNG')
-    assert validate.FileType(['.png'])(PNG_fs) is PNG_fs
-    assert validate.FileType(['.PNG'])(PNG_fs) is PNG_fs
+    PNG_fs = FileStorage(io.BytesIO(b"".ljust(1024)), "test.PNG")
+    assert validate.FileType([".png"])(PNG_fs) is PNG_fs
+    assert validate.FileType([".PNG"])(PNG_fs) is PNG_fs
 
-    with pytest.raises(TypeError, match='A FileStorage object is required, not '):
-        validate.FileType(['.png'])(1)
-
-    with pytest.raises(
-        ValidationError,
-        match=r'Not an allowed file type. Allowed file types: \[.*?\]'  # noqa: W605
-    ):
-        jpg_fs = FileStorage(io.BytesIO(b''.ljust(1024)), 'test.jpg')
-        validate.FileType(['.png'])(jpg_fs)
+    with pytest.raises(TypeError, match="A FileStorage object is required, not "):
+        validate.FileType([".png"])(1)
 
     with pytest.raises(
         ValidationError,
-        match=r'Not an allowed file type. Allowed file types: \[.*?\]'  # noqa: W605
+        match=r"Not an allowed file type. Allowed file types: \[.*?\]",  # noqa: W605
     ):
-        no_ext_fs = FileStorage(io.BytesIO(b''.ljust(1024)), 'test')
-        validate.FileType(['.png'])(no_ext_fs)
+        jpg_fs = FileStorage(io.BytesIO(b"".ljust(1024)), "test.jpg")
+        validate.FileType([".png"])(jpg_fs)
+
+    with pytest.raises(
+        ValidationError,
+        match=r"Not an allowed file type. Allowed file types: \[.*?\]",  # noqa: W605
+    ):
+        no_ext_fs = FileStorage(io.BytesIO(b"".ljust(1024)), "test")
+        validate.FileType([".png"])(no_ext_fs)

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -1,0 +1,92 @@
+import io
+
+import pytest
+from marshmallow.exceptions import ValidationError
+from werkzeug.datastructures import FileStorage
+
+from flask_marshmallow import validate
+
+
+def test_filesize_min():
+    fs = FileStorage(io.BytesIO(b''.ljust(1024)))
+    assert validate.FileSize(min='1 KiB', max='2 KiB')(fs) is fs
+    assert validate.FileSize(min='0 KiB', max='1 KiB')(fs) is fs
+    assert validate.FileSize()(fs) is fs
+    assert validate.FileSize(min_inclusive=False, max_inclusive=False)(fs) is fs
+    assert validate.FileSize(min='1 KiB', max='1 KiB')(fs) is fs
+
+    with pytest.raises(ValidationError, match='Must be greater than or equal to 2 KiB'):
+        validate.FileSize(min='2 KiB', max='3 KiB')(fs)
+    with pytest.raises(ValidationError, match='Must be greater than or equal to 2 KiB'):
+        validate.FileSize(min='2 KiB')(fs)
+    with pytest.raises(ValidationError, match='Must be greater than 1 KiB'):
+        validate.FileSize(min='1 KiB', max='2 KiB', min_inclusive=False, max_inclusive=True)(fs)
+    with pytest.raises(ValidationError, match='less than 1 KiB'):
+        validate.FileSize(min='1 KiB', max='1 KiB', min_inclusive=True, max_inclusive=False)(fs)
+
+
+def test_filesize_max():
+    fs = FileStorage(io.BytesIO(b''.ljust(2048)))
+    assert validate.FileSize(min='1 KiB', max='2 KiB')(fs) is fs
+    assert validate.FileSize(max='2 KiB')(fs) is fs
+    assert validate.FileSize()(fs) is fs
+    assert validate.FileSize(min_inclusive=False, max_inclusive=False)(fs) is fs
+    assert validate.FileSize(min='2 KiB', max='2 KiB')(fs) is fs
+
+    with pytest.raises(ValidationError, match='less than or equal to 1 KiB'):
+        validate.FileSize(min='0 KiB', max='1 KiB')(fs)
+    with pytest.raises(ValidationError, match='less than or equal to 1 KiB'):
+        validate.FileSize(max='1 KiB')(fs)
+    with pytest.raises(ValidationError, match='less than 2 KiB'):
+        validate.FileSize(min='1 KiB', max='2 KiB', min_inclusive=True, max_inclusive=False)(fs)
+    with pytest.raises(ValidationError, match='greater than 2 KiB'):
+        validate.FileSize(min='2 KiB', max='2 KiB', min_inclusive=False, max_inclusive=True)(fs)
+
+
+def test_filesize_repr():
+    assert (
+        repr(
+            validate.FileSize(
+                min=None, max=None, error=None, min_inclusive=True, max_inclusive=True
+            )
+        )
+        == '<FileSize(min=None, max=None, min_inclusive=True, max_inclusive=True, error=None)>'
+    )
+
+    assert repr(
+        validate.FileSize(
+            min='1 KiB', max='3 KiB', error='foo', min_inclusive=False, max_inclusive=False
+        )
+    ) == "<FileSize(min='1 KiB', max='3 KiB', min_inclusive=False, max_inclusive=False, error='foo')>"  # noqa: E501
+
+
+def test_filesize_wrongtype():
+    with pytest.raises(TypeError, match='A FileStorage object is required, not '):
+        validate.FileSize()(1)
+
+
+def test_filetype():
+    png_fs = FileStorage(io.BytesIO(b''.ljust(1024)), 'test.png')
+    assert validate.FileType(['.png'])(png_fs) is png_fs
+    assert validate.FileType(['.PNG'])(png_fs) is png_fs
+
+    PNG_fs = FileStorage(io.BytesIO(b''.ljust(1024)), 'test.PNG')
+    assert validate.FileType(['.png'])(PNG_fs) is PNG_fs
+    assert validate.FileType(['.PNG'])(PNG_fs) is PNG_fs
+
+    with pytest.raises(TypeError, match='A FileStorage object is required, not '):
+        validate.FileType(['.png'])(1)
+
+    with pytest.raises(
+        ValidationError,
+        match=r'Not an allowed file type. Allowed file types: \[.*?\]'  # noqa: W605
+    ):
+        jpg_fs = FileStorage(io.BytesIO(b''.ljust(1024)), 'test.jpg')
+        validate.FileType(['.png'])(jpg_fs)
+
+    with pytest.raises(
+        ValidationError,
+        match=r'Not an allowed file type. Allowed file types: \[.*?\]'  # noqa: W605
+    ):
+        no_ext_fs = FileStorage(io.BytesIO(b''.ljust(1024)), 'test')
+        validate.FileType(['.png'])(no_ext_fs)


### PR DESCRIPTION
Migrate the `File` field and `FileType` `FileSize` validators from APIFlask(#280). 

Example usage:
```python
class ImageSchema(Schema):
            image = File(required=True, validate=[FileType(['.png'], FileSize(min='1 MiB', max='2 MiB')])
```