### PR TITLE
perf: optimize `get_filestorage_size`

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,14 @@
 Changelog
 =========
 
+1.2.0 (unreleased)
+******************
+
+Features:
+
+* Performance improvement to `valdiate.FileSize` (:pr:`293`).
+  Thanks :user:`uncle-lv`.
+
 1.1.0 (2024-01-16)
 ******************
 

--- a/src/flask_marshmallow/validate.py
+++ b/src/flask_marshmallow/validate.py
@@ -13,10 +13,9 @@ from marshmallow.validate import Validator as Validator
 from werkzeug.datastructures import FileStorage
 
 
-def _get_filestorage_size(file):
+def _get_filestorage_size(file: FileStorage) -> int:
     """Return the size of the FileStorage object in bytes."""
-    size = len(file.read())
-    file.stream.seek(0)
+    size: int = file.stream.getbuffer().nbytes  # type: ignore
     return size
 
 

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -7,6 +7,46 @@ from werkzeug.datastructures import FileStorage
 from flask_marshmallow import validate
 
 
+@pytest.mark.parametrize("size", ["1 KB", "1 KiB", "1 MB", "1 MiB", "1 GB", "1 GiB"])
+def test_parse_size(size):
+    rv = validate._parse_size(size)
+    if size == "1 KB":
+        assert rv == 1000
+    elif size == "1 KiB":
+        assert rv == 1024
+    elif size == "1 MB":
+        assert rv == 1000000
+    elif size == "1 MiB":
+        assert rv == 1048576
+    elif size == "1 GB":
+        assert rv == 1000000000
+    elif size == "1 GiB":
+        assert rv == 1073741824
+
+
+def test_get_filestorage_size():
+    rv = validate._get_filestorage_size(FileStorage(io.BytesIO(b"".ljust(0))))
+    assert rv == 0
+    rv = validate._get_filestorage_size(FileStorage(io.BytesIO(b"".ljust(123))))
+    assert rv == 123
+    rv = validate._get_filestorage_size(FileStorage(io.BytesIO(b"".ljust(1024))))
+    assert rv == 1024
+    rv = validate._get_filestorage_size(FileStorage(io.BytesIO(b"".ljust(1234))))
+    assert rv == 1234
+
+
+@pytest.mark.parametrize("size", ["wrong_format", "1.2.3 MiB"])
+def test_parse_size_wrong_value(size):
+    if size == "wrong_format":
+        with pytest.raises(ValueError, match="Invalid size value: "):
+            validate._parse_size(size)
+    elif size == "1.2.3 MiB":
+        with pytest.raises(
+            ValueError, match="Invalid float value while parsing size: "
+        ):
+            validate._parse_size(size)
+
+
 def test_filesize_min():
     fs = FileStorage(io.BytesIO(b"".ljust(1024)))
     assert validate.FileSize(min="1 KiB", max="2 KiB")(fs) is fs


### PR DESCRIPTION
The old `get_filestorage_size` get the size by `len(file.read())` which triggers a read operation and consumes additional memory.
Old version:
```python
def get_filestorage_size(file: FileStorage) -> int:
    size = len(file.read())
    file.stream.seek(0)
    return size
```

The new `get_filestorage_size` get the size by `file.stream.getbuffer().nbytes` which returns the number of bytes of the data directly without any extra overhead.
New version:
```python
def get_filestorage_size(file: FileStorage) -> int:
    size: int = file.stream.getbuffer().nbytes  # type: ignore
    return size
```