### PR TITLE
docs: fix docstring typo error

### DIFF
--- a/src/flask_marshmallow/validate.py
+++ b/src/flask_marshmallow/validate.py
@@ -142,9 +142,10 @@ class FileSize(Validator):
 
 class FileType(Validator):
     """Validator which succeeds if the uploaded file is allowed by a given list
-        of extensions.
+    of extensions.
 
     Example: ::
+
         class ImageSchema(Schema):
             image = File(required=True, validate=FileType(['.png']))
 


### PR DESCRIPTION
Fix a docstring typo error in [validate.py](https://github.com/marshmallow-code/flask-marshmallow/blob/2a3f8e095a888e2ea3c10a7c8f7c8415436b2e87/src/flask_marshmallow/validate.py#L146).