### PR TITLE
Fix validate.FileSize to handle SpooledTemporaryFile

### DIFF
--- a/src/flask_marshmallow/validate.py
+++ b/src/flask_marshmallow/validate.py
@@ -5,6 +5,7 @@ flask_marshmallow.validate
 Custom validation classes for various types of data.
 """
 
+import io
 import os
 import re
 import typing
@@ -16,8 +17,11 @@ from werkzeug.datastructures import FileStorage
 
 def _get_filestorage_size(file: FileStorage) -> int:
     """Return the size of the FileStorage object in bytes."""
-    size: int = file.stream.getbuffer().nbytes  # type: ignore
-    return size
+    stream = file.stream
+    if isinstance(stream, io.BytesIO):
+        return stream.getbuffer().nbytes
+
+    return os.stat(stream.fileno()).st_size
 
 
 # This function is copied from loguru with few modifications.

--- a/src/flask_marshmallow/validate.py
+++ b/src/flask_marshmallow/validate.py
@@ -9,6 +9,7 @@ import io
 import os
 import re
 import typing
+from tempfile import SpooledTemporaryFile
 
 from marshmallow.exceptions import ValidationError
 from marshmallow.validate import Validator as Validator
@@ -21,7 +22,12 @@ def _get_filestorage_size(file: FileStorage) -> int:
     if isinstance(stream, io.BytesIO):
         return stream.getbuffer().nbytes
 
-    return os.stat(stream.fileno()).st_size
+    if isinstance(stream, SpooledTemporaryFile):
+        return os.stat(stream.fileno()).st_size
+
+    size = len(file.read())
+    file.stream.seek(0)
+    return size
 
 
 # This function is copied from loguru with few modifications.

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -1,4 +1,5 @@
 import io
+from tempfile import SpooledTemporaryFile
 
 import pytest
 from flask import url_for
@@ -149,6 +150,12 @@ def test_file_field(ma, mockauthor):
     fs = FileStorage(io.BytesIO(b"test"), "test.jpg")
     result = field.deserialize(fs, mockauthor)
     assert result == fs
+
+    with SpooledTemporaryFile() as temp:
+        temp.write(b"temp")
+        fs = FileStorage(temp, "temp.jpg")
+        result = field.deserialize(fs, mockauthor)
+        assert result == fs
 
     with pytest.raises(ValidationError, match="Field may not be null."):
         field.deserialize(None, mockauthor)

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -1,4 +1,5 @@
 import io
+from tempfile import SpooledTemporaryFile
 
 import pytest
 from marshmallow.exceptions import ValidationError
@@ -33,6 +34,26 @@ def test_get_filestorage_size():
     assert rv == 1024
     rv = validate._get_filestorage_size(FileStorage(io.BytesIO(b"".ljust(1234))))
     assert rv == 1234
+
+    with SpooledTemporaryFile() as temp:
+        temp.write(b"".ljust(0))
+        rv = validate._get_filestorage_size(FileStorage(temp))
+        assert rv == 0
+
+    with SpooledTemporaryFile() as temp:
+        temp.write(b"".ljust(123))
+        rv = validate._get_filestorage_size(FileStorage(temp))
+        assert rv == 123
+
+    with SpooledTemporaryFile() as temp:
+        temp.write(b"".ljust(1024))
+        rv = validate._get_filestorage_size(FileStorage(temp))
+        assert rv == 1024
+
+    with SpooledTemporaryFile() as temp:
+        temp.write(b"".ljust(1234))
+        rv = validate._get_filestorage_size(FileStorage(temp))
+        assert rv == 1234
 
 
 @pytest.mark.parametrize("size", ["wrong_format", "1.2.3 MiB"])


### PR DESCRIPTION
There was a big mistake caused by my carelessness!

The `stream` of `FileStorage` is not always `BytesIO`.
If we upload a file by HTTP clients, it may be a `SpooledTemporaryFile`. Then we get an error message: `AttributeError: 'SpooledTemporaryFile' object has no attribute 'getbuffer'`.

Please release it as soon as possible.

Sorry for this.