### PR TITLE
Fix File field when it receives an empty value

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,14 @@
 Changelog
 =========
 
+1.2.1 (unreleased)
+******************
+
+Bug fixes:
+
+* Fix `File` field when it receives an empty value (:pr:`301`, :issue:`apiflask/apiflask#551`).
+  Thanks :user:`uncle-lv`.
+
 1.2.0 (2024-02-05)
 ******************
 

--- a/src/flask_marshmallow/fields.py
+++ b/src/flask_marshmallow/fields.py
@@ -229,8 +229,8 @@ class File(fields.Field):
     def deserialize(
         self,
         value: typing.Any,
-        attr: str | None = None,
-        data: typing.Mapping[str, typing.Any] | None = None,
+        attr: typing.Optional[str] = None,
+        data: typing.Optional[typing.Mapping[str, typing.Any]] = None,
         **kwargs,
     ):
         if isinstance(value, Sequence) and len(value) == 0:

--- a/src/flask_marshmallow/fields.py
+++ b/src/flask_marshmallow/fields.py
@@ -10,6 +10,7 @@ marshmallow library.
 
 import re
 import typing
+from collections.abc import Sequence
 
 from flask import current_app, url_for
 from marshmallow import fields, missing
@@ -224,6 +225,17 @@ class File(fields.Field):
         self.metadata["format"] = "binary"
 
     default_error_messages = {"invalid": "Not a valid file."}
+
+    def deserialize(
+        self,
+        value: typing.Any,
+        attr: str | None = None,
+        data: typing.Mapping[str, typing.Any] | None = None,
+        **kwargs,
+    ):
+        if isinstance(value, Sequence) and len(value) == 0:
+            value = missing
+        return super().deserialize(value, attr, data, **kwargs)
 
     def _deserialize(self, value, attr, data, **kwargs):
         from werkzeug.datastructures import FileStorage

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -2,6 +2,7 @@ import io
 
 import pytest
 from flask import url_for
+from marshmallow import missing
 from marshmallow.exceptions import ValidationError
 from werkzeug.datastructures import FileStorage
 from werkzeug.routing import BuildError
@@ -149,6 +150,9 @@ def test_file_field(ma, mockauthor):
     fs = FileStorage(io.BytesIO(b"test"), "test.jpg")
     result = field.deserialize(fs, mockauthor)
     assert result == fs
+
+    result = field.deserialize("", mockauthor)
+    assert result is missing
 
     with pytest.raises(ValidationError, match="Field may not be null."):
         field.deserialize(None, mockauthor)


### PR DESCRIPTION
When we don't select a file, swagger send an empty value like this:
```
POST http://localhost:5000/images HTTP/1.1
Content-Type: multipart/form-data; boundary=---------------------------70636434840698183742419445910

-----------------------------70636434840698183742419445910
Content-Disposition: form-data; name="image"


-----------------------------70636434840698183742419445910--
```

Then the value of `File` field(named `image` above) is an empty string, and a `ValidationError("Not a valid file.")` occurs.
But in fact it's missing.