### PR TITLE
Add missing commas to error message for validate.FileType

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,13 @@
 Changelog
 =========
 
+unreleased
+**********
+
+Bug fixes:
+
+* Add missing commas in error message for ``validate.FileType`` (:pr:`374`).
+
 1.3.0 (2025-01-06)
 ******************
 

--- a/src/flask_marshmallow/validate.py
+++ b/src/flask_marshmallow/validate.py
@@ -180,7 +180,7 @@ class FileType(Validator):
 
     def _format_error(self, value):
         return (self.error or self.default_message).format(
-            input=value, extensions="".join(self.allowed_types)
+            input=value, extensions=",".join(self.allowed_types)
         )
 
     def __call__(self, value):

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -1,4 +1,5 @@
 import io
+import re
 from tempfile import SpooledTemporaryFile
 
 import pytest
@@ -162,7 +163,7 @@ def test_filetype():
 
     with pytest.raises(
         ValidationError,
-        match=r"Not an allowed file type. Allowed file types: \[.*?\]",  # noqa: W605
+        match=re.escape("Not an allowed file type. Allowed file types: [.png,.jpg]"),  # noqa: W605
     ):
         no_ext_fs = FileStorage(io.BytesIO(b"".ljust(1024)), "test")
-        validate.FileType([".png"])(no_ext_fs)
+        validate.FileType([".png", ".jpg"])(no_ext_fs)

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -1,5 +1,4 @@
 import io
-import re
 from tempfile import SpooledTemporaryFile
 
 import pytest
@@ -163,7 +162,7 @@ def test_filetype():
 
     with pytest.raises(
         ValidationError,
-        match=re.escape("Not an allowed file type. Allowed file types: [.png,.jpg]"),  # noqa: W605
+        match=r"Not an allowed file type. Allowed file types: \[.*?\]",  # noqa: W605
     ):
         no_ext_fs = FileStorage(io.BytesIO(b"".ljust(1024)), "test")
         validate.FileType([".png", ".jpg"])(no_ext_fs)


### PR DESCRIPTION
When validating file type with a type list:
```python
no_ext_fs = FileStorage(io.BytesIO(b"".ljust(1024)), "test")
validate.FileType([".png", ".jpg"])(no_ext_fs)
```

Expected error info: `Not an allowed file type. Allowed file types: [.png,.jpg]`
Actual error info: `Not an allowed file type. Allowed file types: [.png.jpg]`

The comma as separator is missing.