### PR TITLE
fix: session assignment for SQLAlchemyAutoSchema ResourceWarning on Python 3.13 (Fixes #345)

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,14 @@
 Changelog
 =========
 
+(unreleased)
+************
+
+Bug fixes:
+
+* Fix setting of scoped session on ``SQLAlchemyAuto`` (:pr:`382`).
+  Thanks :user:`galuszkak` for the PR.
+
 1.4.0 (2026-02-04)
 ******************
 

--- a/src/flask_marshmallow/__init__.py
+++ b/src/flask_marshmallow/__init__.py
@@ -134,12 +134,15 @@ class Marshmallow:
         # If using Flask-SQLAlchemy, attach db.session to SQLAlchemySchema
         if has_sqla and "sqlalchemy" in app.extensions:
             db = app.extensions["sqlalchemy"]
-            SQLAlchemySchemaOpts = typing.cast(
-                sqla.SQLAlchemySchemaOpts, self.SQLAlchemySchema.OPTIONS_CLASS
-            )
-            SQLAlchemySchemaOpts.session = db.session
-            SQLAlchemyAutoSchemaOpts = typing.cast(
-                sqla.SQLAlchemyAutoSchemaOpts, self.SQLAlchemySchema.OPTIONS_CLASS
-            )
-            SQLAlchemyAutoSchemaOpts.session = db.session
+            if self.SQLAlchemySchema is not None:
+                SQLAlchemySchemaOpts = typing.cast(
+                    sqla.SQLAlchemySchemaOpts, self.SQLAlchemySchema.OPTIONS_CLASS
+                )
+                SQLAlchemySchemaOpts.session = db.session
+            if self.SQLAlchemyAutoSchema is not None:
+                SQLAlchemyAutoSchemaOpts = typing.cast(
+                    sqla.SQLAlchemyAutoSchemaOpts,
+                    self.SQLAlchemyAutoSchema.OPTIONS_CLASS,
+                )
+                SQLAlchemyAutoSchemaOpts.session = db.session
         app.extensions[EXTENSION_NAME] = self

--- a/tests/test_sqla.py
+++ b/tests/test_sqla.py
@@ -46,6 +46,10 @@ class TestSQLAlchemy:
 
         yield app_
 
+        if "sqlalchemy" in app_.extensions:
+            db = app_.extensions["sqlalchemy"]
+            db.session.remove()
+            db.engine.dispose()
         ctx.pop()
 
     @pytest.fixture


### PR DESCRIPTION
This PR addresses two issues: a logic error in session assignment for auto-schemas and the resource leak reported in #345:
- Fixed a typo where SQLAlchemyAutoSchemaOpts.session was being incorrectly assigned from self.SQLAlchemySchema.OPTIONS_CLASS. It now correctly uses self.SQLAlchemyAutoSchema.OPTIONS_CLASS
- Test Suite Cleanup: Updated the extapp fixture in tests/test_sqla.py to explicitly call db.session.remove() and db.engine.dispose() during teardown. This ensures that database connections are closed even for tests that use the application factory but not the explicit db fixture, resolving the ResourceWarning: unclosed database failures observed in #345 
